### PR TITLE
Migrate pulse from PULSE.txt to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ The philosophy differs from similar projects by treating small LLMs and digital 
 
 ## Features
 
-- **Persistent memory** — `MEMORIES.txt` (long-term facts, append-based), `PULSE.txt` (active goals / working memory), and `skills/*.md` (reusable procedures) survive restarts and are injected into every prompt
+- **Persistent memory** — `MEMORIES.txt` (long-term facts, append-based), pulse items in SQLite (active goals / working memory with priorities), and `skills/*.md` (reusable procedures) survive restarts and are injected into every prompt
 - **Multi-interface** — Matrix chat (with E2E encryption) and a browser-based web UI run simultaneously; each room / tab has independent conversation history
 - **Sub-session workers** — long-running tasks are delegated to autonomous background agents that report back when done; the main agent stays responsive during execution; workers auto-resume after timeouts (up to 3 hops)
 - **Workflow DAG** — multi-step tasks are expressed as dependency graphs via `depends_on`; downstream tasks auto-start when their dependencies complete, with results passed as context — no LLM decision-making needed after the initial plan; tasks can include `not_before` time gates for scheduled execution ("research now, upload after 20:00")
 - **Tool-filtered workers** — minimal workers receive only execution + research tools; `full`-mode workers get orchestration tools too, keeping context lean
 - **Web search** — `search_web` queries a local SearXNG instance and falls back to DuckDuckGo via `curl` when SearXNG is unavailable; `fetch_url` fetches and strips any web page
 - **Reminders & scheduler** — one-time and recurring reminders with optional AI inference on trigger; per-timezone scheduling
-- **Nightly dreaming** — automatic overnight consolidation of MEMORIES.txt and PULSE.txt via a direct LLM call (no tool loop, no conversation side effects)
-- **Pulse reviews** — periodic autonomous reviews of PULSE.txt via an isolated sub-session (no conversation pollution)
+- **Nightly dreaming** — automatic overnight consolidation of MEMORIES.txt and pulse items via a direct LLM call (no tool loop, no conversation side effects)
+- **Pulse reviews** — periodic autonomous reviews of active pulse items via an isolated sub-session (no conversation pollution)
 - **Context compaction** — when conversation history approaches the model's context window, older messages are summarised and chained into a rolling summary that preserves context across compaction cycles
 - **Debug panel** — `http://localhost:8080/debug` provides a live view of sessions, sub-sessions, scheduled jobs, reminders, and the current system prompt
 - **Any OpenAI-compatible backend** — Ollama, vLLM, LM Studio, OpenAI, or any compatible endpoint

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -148,7 +148,7 @@ llm:
   # Also used by pulse reviews (pulse spawns sub-sessions internally).
   sub_sessions: ["local_large"]
 
-  # Dreaming — nightly autonomous memory consolidation (MEMORIES.txt, PULSE.txt).
+  # Dreaming — nightly autonomous memory consolidation (MEMORIES.txt, pulse DB items).
   # Runs once per night; a smaller model keeps costs low.
   dreaming: ["local_small"]
 
@@ -164,8 +164,8 @@ llm:
 # max_tokens in the backend definition.
 
 # ── Pulse Reviews ─────────────────────────────────────────────────
-# Periodic autonomous review of PULSE.txt.  Spawns a sub-session to
-# read the pulse file and take actions (set reminders, update memories, etc.).
+# Periodic autonomous review of active pulse items.  Spawns a sub-session to
+# list pulse items and take actions (complete items, set reminders, update memories, etc.).
 pulse:
   enabled: true                           # Set to false to disable pulse reviews entirely
   review_interval_minutes: 60             # Minutes between automatic reviews
@@ -176,12 +176,12 @@ pulse:
 context:
   component_size_limits:
     memories: 10000                       # MEMORIES.txt char limit
-    pulse: 5000                           # PULSE.txt char limit
+    pulse: 5000                           # Pulse items (DB) char limit
     skills_total: 20000                   # Total chars across all skills/*.md
 
 # ── Dreaming (Nightly Consolidation) ─────────────────────────────
 # Autonomous nightly pass that prunes and consolidates MEMORIES.txt
-# and PULSE.txt.  Uses a direct LLM call (no tool loop).
+# and pulse items.  Uses a direct LLM call (no tool loop).
 dreaming:
   hour: 1                                 # Hour (0-23, UTC) to run consolidation
   minute: 0                               # Minute (0-59)

--- a/data/BASE_PROMPT.txt
+++ b/data/BASE_PROMPT.txt
@@ -5,7 +5,7 @@ You are a personal AI assistant operating through Matrix chat. You have persiste
 Your system prompt is assembled fresh on every message from these components:
 
 - MEMORIES.txt — Long-term facts: user preferences, biographical details, established decisions, relationship context. Anything that remains true across weeks or months belongs here. Updated with append_memory (day-to-day) or update_memories (restructuring only).
-- PULSE.txt — Active working memory: ongoing projects, current goals, time-sensitive tasks, open questions. Items here have a lifespan — they are added when work begins and removed when resolved. Updated with update_pulse (full rewrite each time — drop completed items, keep active ones).
+- Pulse (DB) — Active working memory: ongoing projects, current goals, time-sensitive tasks, open questions. Items here have a lifespan — they are added when work begins and completed when resolved. Managed with the pulse tool (add, complete, update, list actions). Each item has a priority (1=urgent, 10=low) and an ID shown as #N in your prompt.
 - skills/*.md — Documented procedures you have learned. Loaded into every prompt automatically.
 - scripts/ — Supporting scripts referenced by skills. Written via write_file.
 
@@ -18,14 +18,14 @@ When to write memories:
 Never store credentials in MEMORIES. Nightly consolidation automatically deduplicates and prunes.
 
 When to write pulse:
-1. A new project or goal is established → add it to pulse.
-2. An existing goal's status changes → rewrite pulse with updated status.
-3. A goal is completed or abandoned → rewrite pulse without it.
+1. A new project or goal is established → pulse(action="add", content="...", priority=5).
+2. An existing goal's status changes → pulse(action="update", item_id=N, content="updated text").
+3. A goal is completed or abandoned → pulse(action="complete", item_id=N).
 
 # Background processes (automatic, not user-visible)
 
-- Pulse review: every 60 minutes, an autonomous worker reviews PULSE.txt and takes actions (sets reminders, updates memories, etc.) without appearing in your conversation.
-- Nightly dreaming: once per night, MEMORIES.txt and PULSE.txt are consolidated by an LLM — duplicates merged, stale entries pruned. You do not need to manually maintain compactness.
+- Pulse review: every 60 minutes, an autonomous worker reviews active pulse items and takes actions (sets reminders, updates memories, completes items, etc.) without appearing in your conversation.
+- Nightly dreaming: once per night, MEMORIES.txt and pulse items are consolidated by an LLM — duplicates merged, stale entries pruned. You do not need to manually maintain compactness.
 - Context compaction: when conversation history approaches the context window limit, older messages are summarised and archived. A compaction summary is injected into your system prompt. You may notice a [Conversation Summary] section — this is normal.
 
 # Tools
@@ -33,7 +33,7 @@ When to write pulse:
 Orchestration:
 - append_memory — append a fact to MEMORIES.txt (preferred for day-to-day use)
 - update_memories — full rewrite of MEMORIES.txt (only for restructuring or removing entries; read_file first)
-- update_pulse — full rewrite of PULSE.txt (always reconstruct from what you see in your prompt)
+- pulse — manage pulse items: add, complete, update, list (working memory for ongoing tasks)
 - add_skill — document a reusable procedure in skills/
 - set_reminder — schedule one-time or recurring reminders
 - list_reminders — view all scheduled reminders

--- a/data/DREAM_PULSE_PROMPT.txt
+++ b/data/DREAM_PULSE_PROMPT.txt
@@ -1,12 +1,12 @@
-Below is the current content of PULSE.txt — the active pulse working memory (ongoing goals, recurring tasks) for a personal AI assistant.
+Below are the active pulse items (working memory) for a personal AI assistant.
 
-Your task is to consolidate it:
-- Remove completed or clearly stale items.
-- Merge duplicate or overlapping goals.
-- Keep all genuinely active tasks.
-- Return the result as a concise, well-structured list.
+Review each item and return a JSON array of actions to take. Valid actions:
+- {"action": "keep", "id": <id>} — item is still relevant, no change
+- {"action": "complete", "id": <id>} — item is done or clearly stale
+- {"action": "update", "id": <id>, "content": "new text"} — reword/merge
+- {"action": "update", "id": <id>, "priority": <1-10>} — adjust priority
 
-Return ONLY the consolidated PULSE.txt content, with no preamble or explanation.
+Return ONLY the JSON array, no preamble or explanation.
 
---- PULSE.txt ---
+--- Active Pulse Items ---
 {content}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,11 +12,11 @@ Wintermute runs as a single Python asyncio process with several concurrent tasks
 | **SubSessionManager** | `sub_session.py` | Manages background worker sub-sessions and workflow DAGs |
 | **Supervisor** | `supervisor.py` | Post-inference validation: detects hallucinated workflow spawns |
 | **ReminderScheduler** | `scheduler_thread.py` | APScheduler-based reminder system |
-| **PulseLoop** | `pulse.py` | Periodic autonomous PULSE.txt reviews |
+| **PulseLoop** | `pulse.py` | Periodic autonomous pulse item reviews |
 | **DreamingLoop** | `dreaming.py` | Nightly memory consolidation |
 | **GeminiCloudClient** | `gemini_client.py` | AsyncOpenAI-compatible wrapper for Google Cloud Code Assist API (duck-typed drop-in replacement) |
 | **PromptAssembler** | `prompt_assembler.py` | Builds system prompts from file components |
-| **Database** | `database.py` | SQLite message persistence and thread management |
+| **Database** | `database.py` | SQLite message persistence, thread management, and pulse storage |
 
 ## System Diagram
 
@@ -29,7 +29,7 @@ User (Matrix / Browser)
         |
         |-- tool calls --> execute_shell / read_file / write_file
         |                  search_web / fetch_url
-        |                  append_memory / update_memories / update_pulse / add_skill
+        |                  append_memory / update_memories / pulse / add_skill
         |                  set_reminder / list_reminders
         |
         +-- spawn_sub_session --> SubSessionManager
@@ -117,10 +117,10 @@ DreamingLoop (nightly) ------------------> direct LLM API call (no tool loop)
 data/
   BASE_PROMPT.txt            -- Immutable core instructions
   MEMORIES.txt               -- Long-term user facts (updated via append_memory / update_memories)
-  PULSE.txt                  -- Active goals / working memory (updated via update_pulse tool)
+  conversation.db (pulse)    -- Active goals / working memory (managed via pulse tool, stored in SQLite)
   skills/                    -- Learned procedures as *.md files (updated via add_skill tool)
   DREAM_MEMORIES_PROMPT.txt  -- Customisable dreaming prompt for MEMORIES consolidation
-  DREAM_PULSE_PROMPT.txt     -- Customisable dreaming prompt for PULSE consolidation
+  DREAM_PULSE_PROMPT.txt     -- Customisable dreaming prompt for pulse consolidation
   COMPACTION_PROMPT.txt      -- Customisable prompt for context compaction summarisation
   matrix_crypto.db           -- Matrix E2E encryption keys
   matrix_recovery.key        -- Cross-signing recovery key

--- a/docs/autonomy.md
+++ b/docs/autonomy.md
@@ -6,7 +6,7 @@ Wintermute includes several autonomous background systems that operate without u
 
 **Module:** `wintermute/dreaming.py`
 
-A nightly consolidation pass that reviews and prunes MEMORIES.txt and PULSE.txt.
+A nightly consolidation pass that reviews and prunes MEMORIES.txt and pulse DB items.
 
 - Fires at a configurable hour (default: 01:00 UTC)
 - Uses a direct LLM API call — no tool loop, no conversation side effects
@@ -16,7 +16,7 @@ A nightly consolidation pass that reviews and prunes MEMORIES.txt and PULSE.txt.
 
 **Consolidation logic:**
 - MEMORIES.txt: removes duplicates, merges related facts, preserves distinct useful facts
-- PULSE.txt: removes completed/stale items, merges overlapping goals, keeps active tasks
+- Pulse items: LLM returns JSON actions (complete, update, keep) applied via DB; completed items older than 30 days are purged
 
 The prompts used for consolidation are stored in `data/DREAM_MEMORIES_PROMPT.txt` and `data/DREAM_PULSE_PROMPT.txt` and can be customised. See [system-prompts.md](system-prompts.md#customisable-prompt-templates).
 
@@ -24,11 +24,11 @@ The prompts used for consolidation are stored in `data/DREAM_MEMORIES_PROMPT.txt
 
 **Module:** `wintermute/pulse.py`
 
-Periodic autonomous reviews of PULSE.txt.
+Periodic autonomous reviews of active pulse items.
 
 - Runs at a configurable interval (default: every 60 minutes)
 - Spawns an isolated sub-session in `full` mode (fire-and-forget, no parent thread)
-- The sub-session reads PULSE.txt and takes appropriate actions (set reminders, update memories, run commands, etc.)
+- The sub-session lists pulse items via the `pulse` tool and takes appropriate actions (complete items, add new ones, set reminders, update memories, run commands, etc.)
 - Never pollutes any user-facing conversation history
 
 ## Sub-sessions and Workflow DAG
@@ -140,7 +140,7 @@ After every inference, Wintermute checks if any memory component exceeds its siz
 | Component | Default Limit |
 |-----------|---------------|
 | MEMORIES.txt | 10,000 chars |
-| PULSE.txt | 5,000 chars |
+| Pulse (DB) | 5,000 chars |
 | skills/ (total) | 20,000 chars |
 
 When exceeded, a system event is enqueued asking the AI to read, condense, and update the component.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,7 +7,7 @@ All commands are available in both Matrix and the web UI.
 | `/new` | Reset conversation history for the current thread. Archives all messages and clears the compaction summary. Also cancels any running sub-sessions bound to this thread. |
 | `/compact` | Force context compaction. Summarises older messages and archives them, keeping the last 10 messages intact. Shows before/after token counts. |
 | `/reminders` | List all scheduled reminders (active, completed, and failed). |
-| `/pulse` | Manually trigger a pulse review. Enqueues a system event asking the AI to review PULSE.txt and report any actions taken. |
+| `/pulse` | Manually trigger a pulse review. Enqueues a system event asking the AI to review active pulse items and report any actions taken. |
 | `/status` | Show detailed system status: running asyncio tasks, active sub-sessions, workflow state, pulse/dreaming loop status, and reminder count. |
-| `/dream` | Manually trigger the nightly dreaming consolidation of MEMORIES.txt and PULSE.txt. Shows before/after character counts. |
+| `/dream` | Manually trigger the nightly dreaming consolidation of MEMORIES.txt and pulse items. Shows before/after counts. |
 | `/commands` | List all available slash commands with short descriptions. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,14 +92,14 @@ llm:
 # ── Pulse Reviews ─────────────────────────────────────────────────
 pulse:
   enabled: true                           # Set to false to disable pulse reviews
-  review_interval_minutes: 60             # How often to auto-review PULSE.txt
+  review_interval_minutes: 60             # How often to auto-review pulse items
 
 # ── Component Size Limits ─────────────────────────────────────────
 # Characters before a component triggers AI auto-summarisation.
 context:
   component_size_limits:
     memories: 10000                       # MEMORIES.txt
-    pulse: 5000                           # PULSE.txt
+    pulse: 5000                           # Pulse items (DB)
     skills_total: 20000                   # Total across all skills/*.md
 
 # ── Dreaming (Nightly Consolidation) ─────────────────────────────
@@ -262,5 +262,5 @@ See [matrix-setup.md](matrix-setup.md) for full setup instructions.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `memories` | `10000` | Char limit before MEMORIES.txt auto-summarisation |
-| `pulse` | `5000` | Char limit before PULSE.txt auto-summarisation |
+| `pulse` | `5000` | Char limit before pulse auto-summarisation |
 | `skills_total` | `20000` | Total char limit across all skills |

--- a/docs/system-prompts.md
+++ b/docs/system-prompts.md
@@ -26,11 +26,11 @@ Stores persistent facts about the user — preferences, biographical details, es
 
 Key rule: if information would still matter in a month with no active project around it, it belongs in MEMORIES.
 
-### 3. PULSE.txt — Working Memory
+### 3. Pulse (SQLite) — Working Memory
 
-Active goals, ongoing projects, time-sensitive tasks, and open questions. Updated via `update_pulse` (full rewrite — drop completed items, keep active ones). Reviewed autonomously every 60 minutes by the pulse loop and consolidated nightly by the dreaming loop.
+Active goals, ongoing projects, time-sensitive tasks, and open questions. Managed via the `pulse` tool (add, complete, update, list actions). Each item has a priority (1=urgent, 10=low) and an auto-assigned ID. Reviewed autonomously every 60 minutes by the pulse loop and consolidated nightly by the dreaming loop.
 
-Key rule: if it only matters because something is in progress right now, it belongs in PULSE.
+Key rule: if it only matters because something is in progress right now, it belongs in Pulse.
 
 ### 4. skills/*.md — Learned Procedures
 
@@ -57,7 +57,7 @@ The `prompt_assembler.assemble()` function builds the final system prompt:
 ---
 
 # Active Pulse
-{PULSE.txt content}
+{formatted pulse items from DB, e.g. "[P2] #3: Fix auth bug"}
 
 ---
 
@@ -99,12 +99,12 @@ Each component has a configurable character limit (set in `config.yaml` under `c
 | Component | Default Limit | Action When Exceeded |
 |-----------|---------------|---------------------|
 | MEMORIES.txt | 10,000 chars | AI is asked to condense and prioritise |
-| PULSE.txt | 5,000 chars | AI is asked to condense and prioritise |
+| Pulse (DB) | 5,000 chars | AI is asked to condense and prioritise |
 | skills/ (total) | 20,000 chars | AI is asked to reorganise |
 
 When a component exceeds its limit after any inference, a system event is enqueued asking the AI to read the component, condense it, and update it using the appropriate tool.
 
-The nightly dreaming loop also consolidates MEMORIES.txt and PULSE.txt independently using a direct LLM call (no tool loop).
+The nightly dreaming loop also consolidates MEMORIES.txt and pulse items independently using a direct LLM call (no tool loop).
 
 ## Customisable Prompt Templates
 
@@ -113,7 +113,7 @@ The following prompt templates are stored as editable files in `data/` and shipp
 | File | Used By | Placeholder | Purpose |
 |------|---------|-------------|---------|
 | `DREAM_MEMORIES_PROMPT.txt` | Dreaming loop | `{content}` | Instructions for consolidating MEMORIES.txt overnight |
-| `DREAM_PULSE_PROMPT.txt` | Dreaming loop | `{content}` | Instructions for consolidating PULSE.txt overnight |
+| `DREAM_PULSE_PROMPT.txt` | Dreaming loop | `{content}` | Instructions for consolidating pulse items overnight (LLM returns JSON actions) |
 | `COMPACTION_PROMPT.txt` | Context compaction | `{history}` | Instructions for summarising old conversation history |
 
 Templates support an optional placeholder (`{content}` or `{history}`). If present, the relevant text is substituted in. If absent, it is appended to the end of the prompt. This means you can write free-form instructions without worrying about placeholder syntax.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,7 +10,7 @@ Tools are grouped into three categories that control which tools are available i
 |----------|-------------|-------|
 | **execution** | All agents | `execute_shell`, `read_file`, `write_file` |
 | **research** | All agents | `search_web`, `fetch_url` |
-| **orchestration** | Main agent + `full`-mode sub-sessions | `spawn_sub_session`, `set_reminder`, `append_memory`, `update_memories`, `update_pulse`, `add_skill`, `list_reminders` |
+| **orchestration** | Main agent + `full`-mode sub-sessions | `spawn_sub_session`, `set_reminder`, `append_memory`, `update_memories`, `pulse`, `add_skill`, `list_reminders` |
 
 ## Tool Filtering by Sub-session Mode
 
@@ -138,13 +138,17 @@ Overwrite MEMORIES.txt with new content. Use only for restructuring or removing 
 |-----------|------|----------|-------------|
 | `content` | string | yes | Full replacement text for MEMORIES.txt |
 
-#### `update_pulse`
+#### `pulse`
 
-Overwrite PULSE.txt with new content. Include only active items; omit completed goals.
+Manage active pulse items (working memory for ongoing tasks). Pulse items are stored in SQLite — no file rewrites needed.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `content` | string | yes | Full replacement text for PULSE.txt |
+| `action` | enum | yes | `"add"`, `"complete"`, `"list"`, `"update"` |
+| `content` | string | no | Item text (for add/update) |
+| `item_id` | integer | no | Item ID (for complete/update) |
+| `priority` | integer | no | 1 (urgent) to 10 (low), default 5 |
+| `status` | enum | no | Filter for list: `"active"` (default), `"completed"`, `"all"` |
 
 #### `add_skill`
 

--- a/wintermute/main.py
+++ b/wintermute/main.py
@@ -101,7 +101,7 @@ DATA_DIR = Path("data")
 def bootstrap_data_files() -> None:
     """Ensure required data directories exist.
 
-    All prompt files (BASE_PROMPT.txt, MEMORIES.txt, PULSE.txt,
+    All prompt files (BASE_PROMPT.txt, MEMORIES.txt,
     DREAM_*_PROMPT.txt, COMPACTION_PROMPT.txt) are shipped in data/ and
     managed as editable configuration — they are NOT auto-generated.
     """

--- a/wintermute/matrix_thread.py
+++ b/wintermute/matrix_thread.py
@@ -832,7 +832,7 @@ class MatrixThread:
         if text == "/pulse":
             await self._llm.enqueue_system_event(
                 "The user manually triggered a pulse review. "
-                "Review your PULSE.txt and report what actions, if any, you take.",
+                "Review your active pulse items using the pulse tool and report what actions, if any, you take.",
                 thread_id,
             )
             await self.send_message("Pulse review triggered.", thread_id)
@@ -935,8 +935,9 @@ class MatrixThread:
             return
 
         dl = self._dreaming_loop
+        from wintermute import database as db
         mem_before = len(prompt_assembler._read(prompt_assembler.MEMORIES_FILE) or "")
-        pulse_before = len(prompt_assembler._read(prompt_assembler.PULSE_FILE) or "")
+        pulse_before = len(db.list_pulse_items("active"))
 
         await self.send_message("Starting dream cycle...", thread_id)
         try:
@@ -947,12 +948,12 @@ class MatrixThread:
             return
 
         mem_after = len(prompt_assembler._read(prompt_assembler.MEMORIES_FILE) or "")
-        pulse_after = len(prompt_assembler._read(prompt_assembler.PULSE_FILE) or "")
+        pulse_after = len(db.list_pulse_items("active"))
 
         await self.send_message(
             f"Dream cycle complete.\n"
             f"MEMORIES.txt: {mem_before} -> {mem_after} chars\n"
-            f"PULSE.txt: {pulse_before} -> {pulse_after} chars",
+            f"Pulse items: {pulse_before} -> {pulse_after} active",
             thread_id,
         )
 

--- a/wintermute/pulse.py
+++ b/wintermute/pulse.py
@@ -1,7 +1,7 @@
 """
 Pulse Review Loop
 
-Periodically invokes the LLM to review PULSE.txt and take autonomous
+Periodically invokes the LLM to review active pulse items and take autonomous
 actions.  Runs as an isolated sub-session (fire-and-forget, no parent
 thread) so it never pollutes any user-facing conversation history.
 """
@@ -17,10 +17,12 @@ logger = logging.getLogger(__name__)
 
 PULSE_REVIEW_PROMPT = (
     "This is an automatic pulse review. "
-    "Please read your current PULSE.txt using the read_file tool, "
+    "Use the pulse tool with action 'list' to see current items, "
     "then review each item and take any appropriate actions (set reminders, "
-    "update memories, run shell commands, etc.). "
-    "If you update your pulse or take actions, briefly summarise what you did. "
+    "update memories, complete items, run shell commands, etc.). "
+    "Use pulse(action='complete', item_id=...) for finished items, "
+    "and pulse(action='add', content='...') for new items discovered. "
+    "If you take actions, briefly summarise what you did. "
     "If nothing needs attention right now, respond with a short status note."
 )
 

--- a/wintermute/web_interface.py
+++ b/wintermute/web_interface.py
@@ -1618,7 +1618,7 @@ class WebInterface:
             await system("Pulse review triggered.")
             await self._llm.enqueue_system_event(
                 "The user manually triggered a pulse review. "
-                "Review your PULSE.txt and report what actions, if any, you take.",
+                "Review your active pulse items using the pulse tool and report what actions, if any, you take.",
                 thread_id,
             )
             return None
@@ -1705,8 +1705,9 @@ class WebInterface:
             return
 
         dl = self._dreaming_loop
+        from wintermute import database as db
         mem_before = len(prompt_assembler._read(prompt_assembler.MEMORIES_FILE) or "")
-        pulse_before = len(prompt_assembler._read(prompt_assembler.PULSE_FILE) or "")
+        pulse_before = len(db.list_pulse_items("active"))
 
         await system("Starting dream cycle...")
         try:
@@ -1717,12 +1718,12 @@ class WebInterface:
             return
 
         mem_after = len(prompt_assembler._read(prompt_assembler.MEMORIES_FILE) or "")
-        pulse_after = len(prompt_assembler._read(prompt_assembler.PULSE_FILE) or "")
+        pulse_after = len(db.list_pulse_items("active"))
 
         await system(
             f"Dream cycle complete.\n"
             f"MEMORIES.txt: {mem_before} -> {mem_after} chars\n"
-            f"PULSE.txt: {pulse_before} -> {pulse_after} chars"
+            f"Pulse items: {pulse_before} -> {pulse_after} active"
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces file-based `PULSE.txt` with a `pulse` table in `conversation.db`, eliminating token-expensive full-file rewrites and race conditions from concurrent access (pulse loop + dreaming + user writes)
- Single `pulse` tool with `action` parameter (add/complete/update/list) replaces `update_pulse` 1:1, keeping tool count at 12 to minimize schema token cost for small LLMs
- System prompt now injects only active items in compact format (`[P2] #3: Fix auth bug`) instead of verbatim file content
- Dreaming loop uses JSON-action protocol (keep/complete/update) applied via DB functions, with automatic cleanup of completed items older than 30 days
- One-time migration: existing PULSE.txt is parsed line-by-line into DB rows and renamed to `.migrated`

## Files changed (18)

| Area | Files |
|------|-------|
| Core | `database.py`, `prompt_assembler.py`, `tools.py`, `dreaming.py`, `pulse.py` |
| Interfaces | `web_interface.py`, `matrix_thread.py`, `main.py` |
| Prompts | `BASE_PROMPT.txt`, `DREAM_PULSE_PROMPT.txt` |
| Docs | `README.md`, `tools.md`, `system-prompts.md`, `autonomy.md`, `architecture.md`, `configuration.md`, `commands.md`, `config.yaml.example` |

## Test plan

- [ ] Start app → verify `pulse` table exists in `data/conversation.db`
- [ ] If PULSE.txt existed, verify content migrated and file renamed to `.migrated`
- [ ] Chat: ask LLM to add a pulse item → verify in DB and next system prompt
- [ ] Chat: complete an item → verify status='completed', no longer in prompt
- [ ] Run `/pulse` command → verify sub-session uses `pulse` tool
- [ ] Run `/dream` → verify pulse consolidation applies JSON actions
- [ ] Compare system prompt length before/after with active items

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)