### PR TITLE
Fix set_reminder creating passive notifications instead of autonomous tasks

### DIFF
--- a/data/BASE_PROMPT.txt
+++ b/data/BASE_PROMPT.txt
@@ -35,7 +35,7 @@ Orchestration:
 - update_memories — full rewrite of MEMORIES.txt (only for restructuring or removing entries; read_file first)
 - pulse — manage pulse items: add, complete, update, list (working memory for ongoing tasks)
 - add_skill — document a reusable procedure in skills/
-- set_reminder — schedule one-time or recurring reminders
+- set_reminder — schedule one-time or recurring reminders. IMPORTANT: when the user asks you to DO something at a specific time (research, check, monitor, summarise), use ai_prompt to make the reminder autonomous. Without ai_prompt, only a passive notification is sent — the user has to do the work themselves.
 - list_reminders — view all scheduled reminders
 - spawn_sub_session — delegate a task to an autonomous background worker
 
@@ -71,6 +71,22 @@ The task waits for both its dependencies AND the time gate. Use this when the us
 
 For tasks expected to exceed 5 minutes, set timeout accordingly (e.g. 900 for 15 min).
 
+# Scheduled autonomous tasks via set_reminder + ai_prompt
+
+When the user asks you to perform a task at a scheduled time (not immediately), use set_reminder with ai_prompt. This is distinct from a passive reminder — the ai_prompt triggers a full AI inference with tool access when the reminder fires.
+
+Pattern: "research news every morning" →
+  set_reminder(message="Daily news research", ai_prompt="Search for today's top news using search_web with queries for general news, tech news, etc. Fetch the top 3-5 articles with fetch_url and compile a concise bullet-point summary. Present the results clearly.", schedule_type="daily", at="08:00")
+
+Pattern: "check if the site is up in 30 minutes" →
+  set_reminder(message="Site health check", ai_prompt="Use fetch_url to check https://example.com. Report whether it responds successfully and the response time.", schedule_type="once", at="in 30 minutes")
+
+Key rules for ai_prompt:
+- Write ai_prompt as a complete, self-contained task instruction — the executing AI has no conversation context.
+- Mention specific tools to use (search_web, fetch_url, execute_shell, etc.) so the AI knows how to accomplish the task.
+- Thread-bound reminders (default) deliver results to the chat thread. Use system=true only for silent background tasks.
+- When the user says "research X and tell me" or "check Y and let me know" — this ALWAYS requires ai_prompt. A plain reminder without ai_prompt just sends a notification text and does NOT perform any work.
+
 # System events
 
 You will receive messages prefixed with [SYSTEM EVENT]. These come from background processes — sub-session results, reminders, automatic reviews. They are NOT from the user.
@@ -82,6 +98,9 @@ Sub-session results arrive as:
 - [SUB-SESSION sub_xxx TIMEOUT — GIVING UP] — task exhausted all retries. Report partial progress and suggest next steps.
 
 IMPORTANT: When processing a sub-session result, you can only compose a text response — your tools are temporarily unavailable. Summarise the result for the user and, if follow-up actions are needed, tell the user what you plan to do next (you can act on the next turn).
+
+Reminder-triggered tasks arrive as:
+- [REMINDER reminder_xxx] {ai_prompt} — a scheduled ai_prompt has fired. You have FULL tool access. Execute the instructions in the ai_prompt: call search_web, fetch_url, or whatever tools are needed, then deliver the results to the user in chat. Do NOT just repeat the reminder text — actually perform the requested work.
 
 Workflow progress tags like (workflow wf_xxx: 2/3 nodes complete) indicate multi-step progress. You may note workflow progress when reporting a [SYSTEM EVENT] result. Do not fabricate progress.
 

--- a/wintermute/tools.py
+++ b/wintermute/tools.py
@@ -137,7 +137,12 @@ TOOL_SCHEMAS = [
     ),
     _fn(
         "set_reminder",
-        "Schedule a one-time or recurring reminder.",
+        (
+            "Schedule a one-time or recurring reminder. Use ai_prompt to make "
+            "the reminder autonomous — when it fires, an AI inference with full "
+            "tool access executes the prompt and delivers results to chat. "
+            "Without ai_prompt, only a passive text notification is sent."
+        ),
         {
             "type": "object",
             "properties": {
@@ -148,8 +153,16 @@ TOOL_SCHEMAS = [
                 "ai_prompt": {
                     "type": "string",
                     "description": (
-                        "If set, a background AI inference runs with this prompt "
-                        "when the reminder fires. The result is not sent to chat."
+                        "If set, an autonomous AI inference with full tool access "
+                        "(search_web, fetch_url, etc.) runs this prompt when the "
+                        "reminder fires. For thread-bound reminders the result is "
+                        "delivered to chat automatically. ALWAYS set this when the "
+                        "user wants something DONE at a scheduled time (research, "
+                        "monitoring, analysis) — without it, only a passive text "
+                        "notification is sent. Write the prompt as a complete task "
+                        "instruction, e.g. 'Search for today's AI news using "
+                        "search_web, fetch the top 3 articles with fetch_url, and "
+                        "compile a concise summary.'"
                     ),
                 },
                 "schedule_type": {


### PR DESCRIPTION
The ai_prompt parameter description falsely stated "The result is not sent
to chat", causing the LLM to avoid using it when users request scheduled
research/monitoring tasks. The LLM would create plain reminders (passive
text notifications) instead of autonomous task-executing reminders.

Changes:
- Fix ai_prompt description: remove false "not sent to chat" claim, explain
  that thread-bound reminders deliver results to chat, emphasize this is
  required for any scheduled autonomous work
- Improve set_reminder tool description to mention autonomous execution
- Add "Scheduled autonomous tasks" section to BASE_PROMPT with concrete
  patterns (news research, site monitoring) and key rules for ai_prompt
- Add [REMINDER] message handling guidance to System Events section so the
  LLM knows to execute tool calls (not just echo text) when a reminder fires

https://claude.ai/code/session_01Tyy3daxHtdYRwpciqiSLvX