### PR TITLE
feat: two-stage NL translation pipe for complex tool calls

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -89,6 +89,17 @@ turing_protocol:
     phantom_tool_result: true              # detect fabricated tool output claims
     empty_promise: true                    # detect unfulfilled action commitments
 
+# ── NL Translation (Natural-Language Tool Pipe) ──────────────────
+# Simplifies complex tool schemas for weak models by presenting a
+# single "description" field. A translator LLM expands the natural-
+# language description into full structured arguments.
+nl_translation:
+  enabled: false                        # Opt-in; default off
+  backends: ["local_small"]             # Translator LLM (small/fast recommended)
+  tools:                                # Which tools use NL schemas
+    - set_reminder
+    - spawn_sub_session
+
 # ── Context Compaction ────────────────────────────────────────────
 # Compaction fires when history tokens exceed:
 #   context_size - max_tokens - system_prompt_tokens

--- a/data/prompts/NL_TRANSLATOR_SET_REMINDER.txt
+++ b/data/prompts/NL_TRANSLATOR_SET_REMINDER.txt
@@ -1,0 +1,47 @@
+You are a structured-argument translator. The user will give you a natural-language description of a reminder they want to set. Your job is to output ONLY a JSON object (or JSON array for multiple reminders) with the correct arguments for the set_reminder tool.
+
+## set_reminder schema
+
+{{
+  "message": "(string, REQUIRED) Reminder text delivered to chat when it fires.",
+  "ai_prompt": "(string, optional) AI prompt to run when the reminder fires (full tool access). Set whenever the user wants an action performed, not just a notification. Write as a complete task instruction.",
+  "schedule_type": "(string, REQUIRED) One of: once, daily, weekly, monthly, interval",
+  "at": "(string) Required except for interval. For once: ISO-8601 datetime. For recurring: HH:MM (24h).",
+  "day_of_week": "(string) Required for weekly. One of: mon, tue, wed, thu, fri, sat, sun",
+  "day_of_month": "(integer, 1-31) Required for monthly.",
+  "interval_seconds": "(integer, >= 1) Required for interval. Seconds between firings.",
+  "window_start": "(string) For interval: earliest fire time, HH:MM.",
+  "window_end": "(string) For interval: latest fire time, HH:MM.",
+  "system": "(boolean) Fire as a system event with no chat delivery."
+}}
+
+## Rules
+
+1. Output ONLY valid JSON. No explanations, no markdown fences, no text before or after.
+2. Include only keys that are relevant. Omit optional keys that aren't needed.
+3. If the description asks for multiple reminders, return a JSON array of objects.
+4. If the description is ambiguous (e.g. missing time, unclear schedule), return:
+   {{"error": "ambiguous", "clarification_needed": "What specifically is unclear"}}
+5. Use 24-hour HH:MM format for times.
+6. For "once" reminders, use ISO-8601 datetime format for the "at" field.
+7. When the user describes an action to perform (not just a notification), set ai_prompt with a complete task instruction.
+
+## Examples
+
+User: "remind me daily at 9am to check email"
+{{"message": "Check email", "schedule_type": "daily", "at": "09:00"}}
+
+User: "every monday at 8:30 remind me about the team standup"
+{{"message": "Team standup", "schedule_type": "weekly", "at": "08:30", "day_of_week": "mon"}}
+
+User: "set a reminder for 2025-03-15 at 14:00 to call the dentist"
+{{"message": "Call the dentist", "schedule_type": "once", "at": "2025-03-15T14:00:00"}}
+
+User: "every 30 minutes during work hours check if the server is up"
+{{"message": "Server health check", "ai_prompt": "Check if the server is responding by running 'curl -s -o /dev/null -w \"%{{http_code}}\" http://localhost:8080' and report the status.", "schedule_type": "interval", "interval_seconds": 1800, "window_start": "09:00", "window_end": "17:00"}}
+
+User: "remind me about the meeting"
+{{"error": "ambiguous", "clarification_needed": "When should the reminder fire? Please specify a date/time and whether it should be one-time or recurring."}}
+
+User: "remind me on the 1st of every month at noon to pay rent, and also daily at 9am to take my vitamins"
+[{{"message": "Pay rent", "schedule_type": "monthly", "at": "12:00", "day_of_month": 1}}, {{"message": "Take vitamins", "schedule_type": "daily", "at": "09:00"}}]

--- a/data/prompts/NL_TRANSLATOR_SPAWN_SUB_SESSION.txt
+++ b/data/prompts/NL_TRANSLATOR_SPAWN_SUB_SESSION.txt
@@ -1,0 +1,38 @@
+You are a structured-argument translator. The user will give you a natural-language description of a background task (or tasks) to spawn. Your job is to output ONLY a JSON object (or JSON array for multiple tasks) with the correct arguments for the spawn_sub_session tool.
+
+## spawn_sub_session schema
+
+{{
+  "objective": "(string, REQUIRED) Task description. The worker has no conversation access — be specific and self-contained.",
+  "context_blobs": "(array of strings, optional) Context snippets for the worker. Unneeded when using depends_on.",
+  "system_prompt_mode": "(string, optional) One of: minimal (default, lightweight), full (complete context with memories/skills), base_only (core instructions only), none (no system prompt).",
+  "timeout": "(integer, optional) Max seconds before timeout. Default: 300.",
+  "depends_on": "(array of strings, optional) Session IDs to wait for; results auto-passed as context.",
+  "depends_on_previous": "(boolean, optional) If true, depend on all sessions spawned so far in this context. Prefer this over manually listing IDs.",
+  "not_before": "(string, optional) Earliest start time, ISO-8601. Waits even if deps are satisfied."
+}}
+
+## Rules
+
+1. Output ONLY valid JSON. No explanations, no markdown fences, no text before or after.
+2. Include only keys that are relevant. Omit optional keys that aren't needed.
+3. If the description implies multiple sequential tasks (A then B), return a JSON array where later tasks use "depends_on_previous": true.
+4. If the description implies multiple independent tasks, return a JSON array without dependencies.
+5. If the description is ambiguous or too vague to create a useful objective, return:
+   {{"error": "ambiguous", "clarification_needed": "What specifically is unclear"}}
+6. Write objectives as complete, self-contained task instructions.
+7. Default to "minimal" system_prompt_mode. Use "full" only when the task needs access to memories, skills, or orchestration tools (spawning sub-tasks, setting reminders).
+
+## Examples
+
+User: "research the latest news about AI safety"
+{{"objective": "Search the web for the latest news and developments in AI safety from the past week. Summarize the top 3-5 most significant stories with sources."}}
+
+User: "research X then summarize it"
+[{{"objective": "Research X thoroughly using web search. Collect key facts, sources, and different perspectives. Present findings in a structured format."}}, {{"objective": "Summarize the research findings into a concise briefing with key takeaways, organized by theme.", "depends_on_previous": true}}]
+
+User: "check the weather in Berlin and Tokyo at the same time"
+[{{"objective": "Search the web for the current weather conditions in Berlin, Germany. Report temperature, conditions, and forecast."}}, {{"objective": "Search the web for the current weather conditions in Tokyo, Japan. Report temperature, conditions, and forecast."}}]
+
+User: "do the thing"
+{{"error": "ambiguous", "clarification_needed": "What task should the background worker perform? Please describe the specific objective."}}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ Wintermute runs as a single Python asyncio process with several concurrent tasks
 | **PulseLoop** | `pulse.py` | Periodic autonomous pulse item reviews |
 | **DreamingLoop** | `dreaming.py` | Nightly memory consolidation |
 | **GeminiCloudClient** | `gemini_client.py` | AsyncOpenAI-compatible wrapper for Google Cloud Code Assist API (duck-typed drop-in replacement) |
+| **NL Translator** | `nl_translator.py` | Expands natural-language tool descriptions into structured arguments via a translator LLM |
 | **PromptAssembler** | `prompt_assembler.py` | Builds system prompts from file components |
 | **Database** | `database.py` | SQLite message persistence, thread management, and pulse storage |
 
@@ -78,7 +79,9 @@ DreamingLoop (nightly) ------------------> direct LLM API call (no tool loop)
 4. System prompt is assembled fresh (BASE + MEMORIES + PULSE + SKILLS + compaction summary)
 5. If history tokens exceed the compaction threshold, context is compacted first
 6. Message is saved to the DB, then inference runs
-7. If the model returns tool calls, they are executed and inference continues
+7. If the model returns tool calls:
+   - If NL translation is enabled and the call uses a simplified schema, the translator LLM expands the description into structured arguments
+   - Tools are executed and inference continues
 8. Final response is saved to the DB and broadcast back to the user
 9. Turing Protocol fires asynchronously (if enabled): runs a three-stage
    pipeline (detect → validate → correct) against the response, scoped by

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,17 @@ turing_protocol:
     phantom_tool_result: true              # detect fabricated tool output claims
     empty_promise: true                    # detect unfulfilled action commitments
 
+# ── NL Translation (Natural-Language Tool Pipe) ──────────────────
+# Simplifies complex tool schemas for weak models by presenting a
+# single "description" field. A translator LLM expands the natural-
+# language description into full structured arguments.
+nl_translation:
+  enabled: false                        # Opt-in; default off
+  backends: ["local_small"]             # Translator LLM (small/fast recommended)
+  tools:                                # Which tools use NL schemas
+    - set_reminder
+    - spawn_sub_session
+
 # ── Context Compaction ────────────────────────────────────────────
 # Compaction fires when history tokens exceed:
 #   context_size - max_tokens - system_prompt_tokens
@@ -310,6 +321,27 @@ turing_protocol:
       enabled: true
       scope: "sub_session"          # "main", "sub_session", or both
 ```
+
+### `nl_translation`
+
+Natural-language tool call translation for weak/small LLMs. When enabled,
+complex tools (`set_reminder`, `spawn_sub_session`) are presented to the
+main LLM as a single "describe in English" field. A dedicated translator
+LLM expands the description into structured arguments.
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `enabled` | no | `false` | Enable NL translation (opt-in) |
+| `backends` | no | turing_protocol backends | Ordered list of backend names for the translator LLM |
+| `tools` | no | `[set_reminder, spawn_sub_session]` | Which tools use simplified NL schemas |
+
+The translator can return JSON arrays to schedule multiple reminders or
+spawn multiple sub-sessions from a single description. Ambiguous input
+triggers a clarification request back to the user.
+
+Complementary to the Turing Protocol's `tool_schema_validation` hook —
+validation runs on the *translated* structured arguments, not the raw
+description.
 
 ### `matrix`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -151,6 +151,32 @@ Create or overwrite a skill documentation file in `data/skills/`.
 | `skill_name` | string | yes | Filename stem (no extension), e.g. `"calendar"` |
 | `documentation` | string | yes | Markdown documentation for the skill |
 
+## NL Translation Mode
+
+When `nl_translation.enabled: true` in config, `set_reminder` and
+`spawn_sub_session` are presented to the main LLM with simplified
+single-field schemas. Instead of filling in all structured parameters,
+the LLM writes a plain-English description:
+
+```json
+{"description": "remind me daily at 9am to check email"}
+```
+
+A dedicated translator LLM then expands this into the full structured
+arguments (`schedule_type`, `at`, `message`, etc.) before execution.
+The tool result includes a `[Translated to: ...]` prefix showing the
+expanded arguments.
+
+The translator can return JSON arrays for multi-item requests (e.g.
+"set three reminders" or "research X then summarize it") — each item
+is executed separately and results are combined.
+
+If the description is ambiguous, the translator returns a clarification
+request that the main LLM relays to the user.
+
+This feature is complementary to the Turing Protocol's validation hooks,
+which validate the *translated* structured arguments.
+
 #### `list_reminders`
 
 Returns active, completed, and failed reminders. No parameters. History is capped at the 200 most recent entries per category.

--- a/wintermute/nl_translator.py
+++ b/wintermute/nl_translator.py
@@ -1,0 +1,115 @@
+"""
+Natural-Language Tool Call Translator.
+
+Small/weak LLMs frequently produce malformed arguments for complex tools
+like ``set_reminder`` (11 properties) and ``spawn_sub_session`` (DAG
+semantics).  This module presents those tools as single-field "describe
+in English" schemas to the main LLM, then uses a dedicated translator
+LLM to expand the description into structured arguments.
+
+Complementary to the existing ``tool_schema_validation`` Turing Protocol
+hook — the Turing hook validates the *translated* args, not the raw
+description.
+"""
+
+import json
+import logging
+import re
+from typing import Optional
+
+from wintermute import prompt_loader
+from wintermute.llm_thread import BackendPool
+
+logger = logging.getLogger(__name__)
+
+# Tools that have NL translation variants.
+NL_TOOLS: frozenset[str] = frozenset({"set_reminder", "spawn_sub_session"})
+
+# Maps tool name -> prompt template filename.
+_PROMPT_MAP: dict[str, str] = {
+    "set_reminder": "NL_TRANSLATOR_SET_REMINDER.txt",
+    "spawn_sub_session": "NL_TRANSLATOR_SPAWN_SUB_SESSION.txt",
+}
+
+
+def is_nl_tool_call(tool_name: str, tool_args: dict) -> bool:
+    """Detect whether a tool call uses the simplified NL schema.
+
+    Returns True when the tool is NL-eligible and the only argument key
+    is ``"description"``.
+    """
+    return (
+        tool_name in NL_TOOLS
+        and set(tool_args.keys()) == {"description"}
+        and isinstance(tool_args.get("description"), str)
+    )
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Remove markdown code fences (```json ... ```) from LLM output."""
+    text = text.strip()
+    text = re.sub(r"^```(?:json)?\s*\n?", "", text)
+    text = re.sub(r"\n?```\s*$", "", text)
+    return text.strip()
+
+
+async def translate_nl_tool_call(
+    pool: BackendPool,
+    tool_name: str,
+    description: str,
+    thread_id: Optional[str] = None,
+) -> "dict | list | None":
+    """Call the translator LLM to expand a natural-language description
+    into structured tool arguments.
+
+    Returns:
+      - ``dict``  — single tool call arguments
+      - ``list[dict]`` — multiple calls (multi-reminder / multi-spawn)
+      - ``None`` — translation failed (LLM error, unparseable output)
+
+    A dict with an ``"error"`` key signals ambiguity that needs user
+    clarification.
+    """
+    prompt_file = _PROMPT_MAP.get(tool_name)
+    if not prompt_file:
+        logger.error("No NL translator prompt for tool %s", tool_name)
+        return None
+
+    try:
+        system_prompt = prompt_loader.load(prompt_file)
+    except FileNotFoundError:
+        logger.error("NL translator prompt file missing: %s", prompt_file)
+        return None
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": description},
+    ]
+
+    try:
+        response = await pool.call(messages=messages)
+        raw = (response.choices[0].message.content or "").strip()
+    except Exception:
+        logger.exception("NL translator LLM call failed for %s", tool_name)
+        return None
+
+    if not raw:
+        logger.warning("NL translator returned empty response for %s", tool_name)
+        return None
+
+    raw = _strip_markdown_fences(raw)
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("NL translator returned invalid JSON for %s: %s", tool_name, raw[:200])
+        return None
+
+    # Accept dict (single call) or list (multi-call).
+    if isinstance(parsed, dict):
+        return parsed
+    if isinstance(parsed, list) and all(isinstance(item, dict) for item in parsed):
+        return parsed
+
+    logger.warning("NL translator returned unexpected type for %s: %s", tool_name, type(parsed).__name__)
+    return None

--- a/wintermute/prompt_loader.py
+++ b/wintermute/prompt_loader.py
@@ -28,6 +28,26 @@ REQUIRED_FILES = [
 ]
 
 
+NL_TRANSLATION_FILES = [
+    "NL_TRANSLATOR_SET_REMINDER.txt",
+    "NL_TRANSLATOR_SPAWN_SUB_SESSION.txt",
+]
+
+
+def validate_nl_translation() -> None:
+    """Check that NL translation prompt files exist.
+
+    Called from main.py only when ``nl_translation.enabled: true``.
+    """
+    missing = [f for f in NL_TRANSLATION_FILES if not (PROMPTS_DIR / f).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"Missing NL translation prompt files in {PROMPTS_DIR}/: "
+            + ", ".join(missing)
+        )
+    logger.info("NL translation prompt files validated (%d files)", len(NL_TRANSLATION_FILES))
+
+
 def load(name: str, **kwargs: object) -> str:
     """Read a prompt template from *data/prompts/{name}*.
 


### PR DESCRIPTION
## Summary

- Adds an opt-in two-stage inference pipe for `set_reminder` and `spawn_sub_session` — the two tools most likely to produce malformed arguments from weak/small LLMs
- The main LLM sees a simplified single-field `"description"` schema; a dedicated translator LLM expands the natural-language description into full structured arguments before execution
- The translator supports multi-item arrays (schedule multiple reminders or spawn multiple sub-sessions from one description) and ambiguity signaling

## Changes

**New files:**
- `wintermute/nl_translator.py` — core module (`is_nl_tool_call`, `translate_nl_tool_call`)
- `data/prompts/NL_TRANSLATOR_SET_REMINDER.txt` — translator prompt with schema + few-shot examples
- `data/prompts/NL_TRANSLATOR_SPAWN_SUB_SESSION.txt` — same for spawn_sub_session

**Modified files:**
- `wintermute/tools.py` — `NL_TOOL_SCHEMAS`, `_NL_SCHEMA_MAP`, `nl_tools` param in `get_tool_schemas()`
- `wintermute/prompt_loader.py` — `NL_TRANSLATION_FILES`, `validate_nl_translation()`
- `wintermute/main.py` — config parsing, `nl_translation_pool` building, validation, wiring to constructors
- `wintermute/llm_thread.py` — `nl_translation` field in `MultiProviderConfig`, NL params in `LLMThread.__init__`, translation block in `_inference_loop()`
- `wintermute/sub_session.py` — NL params in `SubSessionManager.__init__`, translation block in `_worker_loop()`
- `config.yaml.example` — new `nl_translation:` section (disabled by default)
- `docs/` — configuration, tools, architecture docs updated

## Test plan

- [ ] Start with `nl_translation.enabled: false` (default) — verify no behavior change
- [ ] Enable and test: "remind me daily at 9am to check email" → `set_reminder(description="...")` → translator fires → structured args → `[Translated to: ...]` prefix in result
- [ ] Test ambiguity: "remind me about the meeting" → clarification returned → LLM asks user for details
- [ ] Test multi-item: "remind me daily at 9am and weekly on fridays at 5pm" → translator returns array → two reminders created
- [ ] Test multi-spawn: "research X then summarize it" → translator returns array with `depends_on_previous: true` → sequential sub-sessions
- [ ] Test error path: stop translator backend → `[TRANSLATION ERROR]` in tool result
- [ ] Verify Turing `tool_schema_validation` validates *translated* args (not raw description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)