### PR TITLE
Improve config missing error message

### DIFF
--- a/wintermute/main.py
+++ b/wintermute/main.py
@@ -54,7 +54,7 @@ LOG_DIR = Path("logs")
 
 def load_config(path: Path = CONFIG_FILE) -> dict:
     if not path.exists():
-        print(f"ERROR: {path} not found. Copy config.yaml.example and fill in your settings.")
+        print(f"CRITICAL: Configuration file '{path}' is missing! Please copy config.yaml.example to config.yaml and configure.")
         sys.exit(1)
     with path.open(encoding="utf-8") as fh:
         return yaml.safe_load(fh)


### PR DESCRIPTION
## Summary
Improves the error message when config.yaml is not found to be clearer and more helpful.

## Changes
- Updated error message to "CRITICAL" level for visibility
- Added helpful instruction to use config.yaml.example
- Better wording for clarity

## Testing
- Verified error message displays correctly when config is missing

🤖 Generated with Claude Code