### PR TITLE
fix(prompt_assembler): parse Unix timestamp correctly in _get_reflection_observations

### DIFF
--- a/wintermute/infra/prompt_assembler.py
+++ b/wintermute/infra/prompt_assembler.py
@@ -202,9 +202,7 @@ def _get_reflection_observations() -> str:
         for e in entries:
             ts_str = e.get("timestamp", "")
             try:
-                ts = datetime.fromisoformat(ts_str)
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
+                ts = datetime.fromtimestamp(float(ts_str), tz=timezone.utc)
                 if ts < cutoff:
                     continue
             except (ValueError, TypeError):


### PR DESCRIPTION
## Summary

- `_get_reflection_observations()` was calling `datetime.fromisoformat()` on a float Unix timestamp string stored by the interaction log
- This caused a `ValueError` on every entry, which was silently caught, resulting in the function always returning an empty string
- Reflection findings were therefore never included in the main-thread system prompt

## Fix

Replace `datetime.fromisoformat(ts_str)` with `datetime.fromtimestamp(float(ts_str), tz=timezone.utc)` in `wintermute/infra/prompt_assembler.py` line 205. `timezone` was already imported.

## Test plan

- [ ] Verify that entries exist in the `interaction_log` table with `action` values of `reflection_rule` or `reflection_analysis`
- [ ] Confirm that after the fix, `_get_reflection_observations()` returns a non-empty string when recent entries are present
- [ ] Confirm the main-thread system prompt now includes the reflection section

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)