### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/wintermute/backends/gemini_client.py
+++ b/wintermute/backends/gemini_client.py
@@ -125,7 +125,7 @@ class GeminiCloudClient:
             if time.time() < self._creds.get("expires_at", 0) - 60:
                 return self._creds["access_token"]
             logger.info("Refreshing Gemini access token")
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             self._creds = await loop.run_in_executor(
                 None, gemini_auth.refresh_access_token, self._creds
             )
@@ -427,7 +427,7 @@ class GeminiCloudClient:
             if resp.status_code == 401 and attempt == 0:
                 logger.info("Gemini 401 — refreshing token and retrying")
                 async with self._refresh_lock:
-                    loop = asyncio.get_event_loop()
+                    loop = asyncio.get_running_loop()
                     self._creds = await loop.run_in_executor(
                         None, gemini_auth.refresh_access_token, self._creds
                     )

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -1305,7 +1305,7 @@ async def run_dream_cycle(
             ))
 
     # Auto-commit all changes.
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     await loop.run_in_executor(
         None, data_versioning.auto_commit, "dreaming: nightly consolidation",
     )


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` at 3 call sites in async contexts
- Affected: `gemini_client.py` (2 sites), `dreaming.py` (1 site)

Closes #76

## Test plan
- [ ] Verify no `DeprecationWarning` from asyncio in logs
- [ ] Gemini token refresh and dreaming auto-commit still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)