### PR TITLE
fix: store references to fire-and-forget asyncio tasks

### DIFF
--- a/wintermute/core/llm_thread.py
+++ b/wintermute/core/llm_thread.py
@@ -278,6 +278,7 @@ class LLMThread:
         self._last_system_prompt: dict[str, str] = {}
         # Per-thread last activity timestamp (for session timeout tracking).
         self._last_activity: dict[str, float] = {}
+        self._background_tasks: set[asyncio.Task] = set()
 
     def inject_sub_session_manager(self, manager: "SubSessionManager") -> None:
         """Called after construction once SubSessionManager is built."""
@@ -615,7 +616,7 @@ class LLMThread:
                 # _prior_assistant and _recent_assistant were collected
                 # before _process() above, so they don't include the
                 # current reply.
-                asyncio.create_task(
+                _tp_task = asyncio.create_task(
                     self._run_turing_check(
                         user_message=item.text,
                         assistant_response=reply.text,
@@ -628,6 +629,8 @@ class LLMThread:
                     ),
                     name=f"turing_{item.thread_id}",
                 )
+                self._background_tasks.add(_tp_task)
+                _tp_task.add_done_callback(self._background_tasks.discard)
 
             # Emit main-thread turn event for reflection/synthesis.
             if (


### PR DESCRIPTION
## Summary

- Add `_background_tasks: set[asyncio.Task]` to `LLMThread`, `WebInterface`, and `MatrixThread`
- Store every fire-and-forget `asyncio.create_task()` result in the set with a `add_done_callback` for automatic cleanup
- Prevents GC from destroying pending tasks and silently swallowing exceptions

**7 sites fixed across 3 files:**
| File | Task |
|---|---|
| `llm_thread.py` | `_run_turing_check` |
| `web_interface.py` | `enqueue_user_message` |
| `matrix_thread.py` | `_ensure_cross_signed` |
| `matrix_thread.py` | `_accept_pending_invites` |
| `matrix_thread.py` | `_send_verification_requests` (×2) |
| `matrix_thread.py` | `crypto.request_room_key` |

Closes #68

## Test plan

- [x] All three modules import successfully
- [ ] Verify tasks complete normally (turing checks, web messages, Matrix crypto setup)
- [ ] Confirm no "Task was destroyed but it is pending!" warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)