### PR TITLE
refactor: DRY the fallback pattern in _build_multi_provider_config (#101)

### DIFF
--- a/wintermute/main.py
+++ b/wintermute/main.py
@@ -202,6 +202,16 @@ def _build_multi_provider_config(cfg: dict) -> MultiProviderConfig:
         print(f"ERROR: llm.{name} must be a list of backend names (got {type(raw).__name__})")
         sys.exit(1)
 
+    def _get_role_with_fallback(name: str, fallback: list[ProviderConfig]) -> list[ProviderConfig]:
+        """Resolve a role, falling back to *fallback* when omitted or set to []."""
+        raw = llm_raw.get(name)
+        if raw is None or (isinstance(raw, list) and not raw):
+            return list(fallback)
+        if isinstance(raw, list):
+            return _resolve_role(name, raw, backends)
+        print(f"ERROR: llm.{name} must be a list of backend names (got {type(raw).__name__})")
+        sys.exit(1)
+
     # -- Turing Protocol backends --
     tp_configs = _get_role("turing_protocol", allow_empty=True)
 
@@ -226,33 +236,13 @@ def _build_multi_provider_config(cfg: dict) -> MultiProviderConfig:
 
     # -- Memory Harvest backends --
     # Falls back to sub_sessions backends when omitted (not to first backend).
-    mh_raw = llm_raw.get("memory_harvest")
     sub_sessions_configs = _get_role("sub_sessions")
-    if mh_raw is None:
-        mh_configs = list(sub_sessions_configs)
-    elif isinstance(mh_raw, list):
-        if not mh_raw:
-            mh_configs = list(sub_sessions_configs)  # empty list → fallback
-        else:
-            mh_configs = _resolve_role("memory_harvest", mh_raw, backends)
-    else:
-        print(f"ERROR: llm.memory_harvest must be a list of backend names (got {type(mh_raw).__name__})")
-        sys.exit(1)
+    mh_configs = _get_role_with_fallback("memory_harvest", sub_sessions_configs)
 
     # -- Reflection backends --
     # Falls back to compaction backends when omitted.
-    refl_raw = llm_raw.get("reflection")
     compaction_configs = _get_role("compaction")
-    if refl_raw is None:
-        refl_configs = list(compaction_configs)
-    elif isinstance(refl_raw, list):
-        if not refl_raw:
-            refl_configs = list(compaction_configs)  # empty list → fallback
-        else:
-            refl_configs = _resolve_role("reflection", refl_raw, backends)
-    else:
-        print(f"ERROR: llm.reflection must be a list of backend names (got {type(refl_raw).__name__})")
-        sys.exit(1)
+    refl_configs = _get_role_with_fallback("reflection", compaction_configs)
 
     return MultiProviderConfig(
         main=_get_role("base"),


### PR DESCRIPTION
## Summary

- Adds `_get_role_with_fallback(name, fallback)` nested helper inside `_build_multi_provider_config`
- Replaces two identical 10-line `None → fallback / [] → fallback / list → resolve / else → error` blocks (for `memory_harvest` and `reflection`) with single-line calls
- Net: −22 lines / +12 lines (−10 lines overall)

Behaviour is unchanged; the helper is a direct mechanical extraction of the repeated pattern.

Closes #101

## Test plan

- [ ] Smoke-test startup with `config.yaml` that omits `memory_harvest` and `reflection` — should fall back to `sub_sessions` / `compaction` as before
- [ ] Smoke-test with explicit empty lists (`memory_harvest: []`, `reflection: []`) — same fallback behaviour
- [ ] Smoke-test with explicit backend lists — should resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)