### PR TITLE
refactor: dynamic WHERE builder in list_tasks (#98)

### DIFF
--- a/wintermute/infra/database.py
+++ b/wintermute/infra/database.py
@@ -439,29 +439,20 @@ def delete_task(task_id: str) -> bool:
 
 def list_tasks(status: str = "active", thread_id: Optional[str] = None) -> list[dict]:
     """Return tasks filtered by status, ordered by priority then id."""
+    conditions: list[str] = []
+    params: list = []
+    if status == "all":
+        conditions.append("status != 'deleted'")
+    else:
+        conditions.append("status = ?")
+        params.append(status)
+    if thread_id:
+        conditions.append("thread_id = ?")
+        params.append(thread_id)
+    sql = f"SELECT * FROM tasks WHERE {' AND '.join(conditions)} ORDER BY priority ASC, id ASC"
     with _connect() as conn:
         conn.row_factory = sqlite3.Row
-        if status == "all" and not thread_id:
-            rows = conn.execute(
-                "SELECT * FROM tasks WHERE status != 'deleted' ORDER BY priority ASC, id ASC"
-            ).fetchall()
-        elif status == "all" and thread_id:
-            rows = conn.execute(
-                "SELECT * FROM tasks WHERE status != 'deleted' AND thread_id=? "
-                "ORDER BY priority ASC, id ASC",
-                (thread_id,),
-            ).fetchall()
-        elif thread_id:
-            rows = conn.execute(
-                "SELECT * FROM tasks WHERE status=? AND thread_id=? "
-                "ORDER BY priority ASC, id ASC",
-                (status, thread_id),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT * FROM tasks WHERE status=? ORDER BY priority ASC, id ASC",
-                (status,),
-            ).fetchall()
+        rows = conn.execute(sql, params).fetchall()
     return [dict(r) for r in rows]
 
 


### PR DESCRIPTION
## Summary

- Replaces the 4-branch `if/elif/elif/else` in `list_tasks()` with a small dynamic WHERE clause builder (conditions list + params list)
- A single `conn.execute()` call handles all four input combinations
- Net: −9 lines, behaviour identical for all callers

Closes #98

## Test plan

- [ ] `list_tasks()` (default `status="active"`, no `thread_id`) returns only active tasks
- [ ] `list_tasks("all")` returns all non-deleted tasks
- [ ] `list_tasks("active", thread_id=<id>)` returns active tasks scoped to that thread
- [ ] `list_tasks("all", thread_id=<id>)` returns all non-deleted tasks for that thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)