### PR TITLE
refactor: normalized exception classes for error detection

### DIFF
--- a/wintermute/core/llm_thread.py
+++ b/wintermute/core/llm_thread.py
@@ -34,6 +34,8 @@ from wintermute.core.types import (  # noqa: F401 — re-exported for backwards 
     ContextTooLargeError,
     MultiProviderConfig,
     ProviderConfig,
+    RateLimitError,
+    classify_api_error,
 )
 from wintermute.core.tool_call_rescue import rescue_tool_calls
 from wintermute import tools as tool_module


### PR DESCRIPTION
## Summary
- Add `RateLimitError` exception class alongside existing `ContextTooLargeError`
- Extract error classification into `classify_api_error()` function that returns the normalized error type
- Simplify `BackendPool.call()` to use `classify_api_error()` instead of inline multi-condition string matching
- Centralized phrase list `_CONTEXT_TOO_LARGE_PHRASES` for easy extension

Closes #95

## Test plan
- [x] Manually verified `classify_api_error()` with all error patterns (429, 413, 400+phrase, unknown)
- [x] Verified imports work
- [ ] Full application test with actual provider errors

Note: No automated tests added — the repository does not have a test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)