### PR TITLE
refactor: unify 3 TP check methods into TuringProtocolRunner

### DIFF
--- a/wintermute/core/llm_thread.py
+++ b/wintermute/core/llm_thread.py
@@ -119,7 +119,6 @@ class LLMThread:
         self._main_pool = main_pool
         self._compaction_pool = compaction_pool
         self._turing_protocol_pool = turing_protocol_pool
-        self._turing_protocol_validators = turing_protocol_validators
         from wintermute.core.tp_runner import TuringProtocolRunner
         self._tp_runner = TuringProtocolRunner(
             pool=turing_protocol_pool,

--- a/wintermute/core/sub_session.py
+++ b/wintermute/core/sub_session.py
@@ -275,7 +275,6 @@ class SubSessionManager:
         self._cfg = pool.primary
         self._enqueue = enqueue_system_event
         self._tp_pool = turing_protocol_pool
-        self._tp_validators = turing_protocol_validators
         self._tp_runner = TuringProtocolRunner(
             turing_protocol_pool, "sub_session", turing_protocol_validators,
         )


### PR DESCRIPTION
## Summary
- Extracts near-identical TP validation logic from `LLMThread._run_phase_check`, `LLMThread._run_turing_check`, and `SubSessionManager._run_tp_phase` into a shared `TuringProtocolRunner` class in `wintermute/core/tp_runner.py`
- Runner binds `pool`, `scope`, and `enabled_validators` at construction; callers only pass per-turn arguments
- Both `LLMThread` and `SubSessionManager` now delegate to their respective runner instance

Closes #100

## Test plan
- [ ] Verify main thread TP checks still fire (post_inference, pre_execution, post_execution phases)
- [ ] Verify sub-session TP checks still fire with correct scope and objective
- [ ] Confirm `py_compile` passes for all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)