### PR TITLE
fix: configurable embeddings batch_size to prevent LiteLLM 500 errors

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -472,6 +472,9 @@ memory:
     api_key: ""                           # API key for the embeddings endpoint (if required)
     model: "text-embedding-3-small"
     dimensions: 1536
+    batch_size: 32                        # Max texts per embeddings API call. Lower this if the
+                                          # server returns HTTP 500 "input too large to process"
+                                          # (e.g. LiteLLM with a small physical batch token limit).
 
   # Dreaming (vector-native consolidation settings).
   # Only used when backend is local_vector or qdrant.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,6 +349,7 @@ When any non-`flat_file` backend is active, MEMORIES.txt is kept as a git-versio
 | `model` | no | `"text-embedding-3-small"` | Embedding model name |
 | `dimensions` | no | `1536` | Vector dimensions (must match the model's output and the Qdrant collection) |
 | `send_dimensions` | no | `false` | Send `dimensions` parameter in the embedding request (only OpenAI supports this) |
+| `batch_size` | no | `32` | Maximum number of texts sent per embeddings API call. Reduce if the server returns HTTP 500 "input too large to process" (e.g. LiteLLM with a low physical batch token limit). |
 
 #### `memory.qdrant` (qdrant only)
 


### PR DESCRIPTION
## Summary

- **Root cause:** `_embed()` sent all texts in a single HTTP POST. During `replace_all()` / `rebuild()`, the full memory list is passed at once — when combined token count exceeds the server's physical batch limit (LiteLLM default: 1024 tokens), the endpoint returns HTTP 500 `"input too large to process"`.
- Added `memory.embeddings.batch_size` config key (default: `32` texts/call) — `_embed()` now chunks large inputs and makes multiple requests, concatenating results.
- Extracted a `_embed_batch()` helper that logs the full server response body on 5xx, with a hint pointing to `batch_size` to make the diagnosis transparent.
- Updated `config.yaml.example` and `docs/configuration.md`.

## Test plan

- [ ] With `batch_size: 32` set, trigger a `replace_all` (e.g. via dreaming or `/dream`) with >32 memory entries — verify no 500 errors
- [ ] Verify that a 5xx from the embeddings endpoint now logs the server body and the `batch_size` hint at WARNING level
- [ ] Verify single-entry embeds (search queries, `add()`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)