### PR TITLE
fix: address 4 more Copilot review findings

### DIFF
--- a/docs/system-prompts.md
+++ b/docs/system-prompts.md
@@ -108,7 +108,7 @@ The `prompt_assembler.assemble()` function builds the final system prompt. It ac
 
 ---
 
-# Operational Self-Model                  (main thread only, if self-model exists)
+# Operational Self-Model                  (main thread only, when self-model profiling is enabled at startup)
 {self-model prose summary, ≤300 chars}
 
 ---

--- a/wintermute/workers/reflection.py
+++ b/wintermute/workers/reflection.py
@@ -83,6 +83,8 @@ def _extract_json_tail(text: str) -> dict | None:
     decoder = json.JSONDecoder()
     # Find all candidate opening braces and try from the last one backwards.
     brace_positions = [m.start() for m in re.finditer(r"\{", text)]
+    if not brace_positions:
+        return None
     for start in reversed(brace_positions):
         try:
             obj, end = decoder.raw_decode(text[start:])
@@ -868,9 +870,9 @@ class ReflectionLoop:
                     content,
                     5,  # priority
                     None,  # thread_id
-                    None,  # schedule_type — unscheduled; scheduling configured separately
-                    None,  # schedule_desc
-                    None,  # schedule_config
+                    ta.get("schedule_type"),   # schedule_type (may be None)
+                    ta.get("schedule_desc"),   # schedule_desc (may be None)
+                    ta.get("schedule_config"), # schedule_config (may be None)
                     ta["ai_prompt"],  # ai_prompt
                     True,  # background
                 )

--- a/wintermute/workers/scheduler_thread.py
+++ b/wintermute/workers/scheduler_thread.py
@@ -582,6 +582,11 @@ class TaskScheduler:
                 # Clear the last-activity marker so this thread is not
                 # repeatedly treated as expired on subsequent checks.
                 self._session_manager.last_activity.pop(tid, None)
+                # Clear any per-thread tool-call history so cross-turn TP
+                # checks don't see pre-reset tool usage after a timeout reset.
+                prior_tool_calls = getattr(self._session_manager, "prior_tool_calls", None)
+                if isinstance(prior_tool_calls, dict):
+                    prior_tool_calls.pop(tid, None)
                 if self._event_bus:
                     self._event_bus.emit("session.timeout_reset", thread_id=tid)
             except Exception:


### PR DESCRIPTION
- Docs: clarify self-model injection is gated on profiler being enabled
- reflection: early return when no opening braces found in JSON extractor
- scheduler: clear prior_tool_calls on session timeout reset to prevent stale TP cross-turn state leaking into post-reset turns
- reflection: pass through schedule_type/desc/config from task_actions instead of always setting None