### PR TITLE
fix: ensure legacy turing_* actions get convergence color coding in d…

### DIFF
--- a/wintermute/infra/database.py
+++ b/wintermute/infra/database.py
@@ -574,8 +574,14 @@ def get_interaction_log(limit: int = 200, offset: int = 0,
         conditions.append("session=?")
         params.append(session_filter)
     if action_filter:
-        conditions.append("action=?")
-        params.append(action_filter)
+        # Also match legacy turing_* action names for convergence_* filters.
+        legacy = action_filter.replace("convergence_", "turing_", 1) if action_filter.startswith("convergence_") else None
+        if legacy and legacy != action_filter:
+            conditions.append("action IN (?, ?)")
+            params.extend([action_filter, legacy])
+        else:
+            conditions.append("action=?")
+            params.append(action_filter)
     if before_id is not None:
         conditions.append("id < ?")
         params.append(before_id)
@@ -621,8 +627,13 @@ def count_interaction_log(session_filter: Optional[str] = None,
         conditions.append("session=?")
         params.append(session_filter)
     if action_filter:
-        conditions.append("action=?")
-        params.append(action_filter)
+        legacy = action_filter.replace("convergence_", "turing_", 1) if action_filter.startswith("convergence_") else None
+        if legacy and legacy != action_filter:
+            conditions.append("action IN (?, ?)")
+            params.extend([action_filter, legacy])
+        else:
+            conditions.append("action=?")
+            params.append(action_filter)
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
     with _connect() as conn:
         row = conn.execute(

--- a/wintermute/interfaces/static/debug.html
+++ b/wintermute/interfaces/static/debug.html
@@ -1411,7 +1411,7 @@ function _makeILRow(e) {
   const outputPreview = (e.output || '').length > 120 ? e.output.slice(0, 117) + '\u2026' : (e.output || '');
   const statusCls = e.status === 'ok' ? 'completed' : (e.status === 'error' ? 'failed' : 'pending');
   const sessionShort = (e.session || '').length > 24 ? e.session.slice(0, 22) + '\u2026' : (e.session || '');
-  const actionStyle = e.action.startsWith('convergence') ? 'convergence' : (e.action === 'tool_call' ? 'tool' : (e.action === 'chat' ? 'web' : (e.action === 'inference_round' ? 'pending' : (e.action === 'error' ? 'failed' : 'system'))));
+  const actionStyle = (e.action.startsWith('convergence') || e.action.startsWith('turing')) ? 'convergence' : (e.action === 'tool_call' ? 'tool' : (e.action === 'chat' ? 'web' : (e.action === 'inference_round' ? 'pending' : (e.action === 'error' ? 'failed' : 'system'))));
   const _rowBg = e.action === 'tool_call' ? ';background:#0a0f1a' : (e.action === 'inference_round' ? ';background:#0a1020' : '');
   return (
     '<tr style="cursor:pointer' + _rowBg + '" onclick="toggleILDetail(this, ' + e.id + ')">' +


### PR DESCRIPTION
…ebug UI

- JS badge logic now matches both 'convergence' and 'turing' prefixes for the purple convergence badge styling
- DB interaction log queries (get/count) transparently include legacy turing_* rows when filtering by convergence_* action names