### PR TITLE
feat: add send_file tool, replace text-marker parsing

### DIFF
--- a/data/prompts/BASE_PROMPT.txt
+++ b/data/prompts/BASE_PROMPT.txt
@@ -16,17 +16,11 @@ Every new information goes to exactly ONE store:
 
 MEMORY — persistent facts (identity, preferences, environment). NOT procedures or goals.
 
-TASK — goals, reminders, scheduled actions.
-- Scheduled + autonomous: set ai_prompt (self-contained instruction) → spawns background sub-session.
-- Without ai_prompt: passive ⏰ reminder only — NOTHING executes.
-- Unscheduled: tracked goal. Complete with reason when done.
+TASK — goals, reminders, scheduled actions. Complete with reason when done.
 
 SKILL — reusable how-to procedures. NOT one-off tasks, NOT facts.
-- Create/update: skill tool with action "add"
-- Retrieve by name: skill tool with action "read"
-- Find by topic: skill tool with action "search"
 
-Shortcut: "User likes X" → memory | "Do X daily at 9" → task+schedule | "Track X" → task | "How to X" → skill
+Shortcut: "User likes X" → memory | "Do X daily" → task | "Track X" → task | "How to X" → skill
 
 <!-- section: delegation requires: worker_delegation -->
 # Delegation
@@ -80,7 +74,6 @@ ACT FIRST. Use tools when intent is clear — don't narrate plans.
 
 - Concise output. No disclaimers, no hedging, no filler.
 - Confirm time + task_id after scheduling.
-- Send files: write first, then [send_file:/absolute/path] in response.
 - NEVER fabricate tool output or claim actions not taken.
 - NEVER mention session IDs not received from worker_delegation.
 - NEVER simulate progress. Call the tool or state you cannot.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-Wintermute exposes 10 tools as OpenAI-compatible function-calling schemas, compatible with any OpenAI-compatible endpoint (llama-server, vLLM, LM Studio, OpenAI, etc.).
+Wintermute exposes 11 tools as OpenAI-compatible function-calling schemas, compatible with any OpenAI-compatible endpoint (llama-server, vLLM, LM Studio, OpenAI, etc.).
 
 ## Tool Categories
 
@@ -8,7 +8,7 @@ Tools are grouped into three categories that control which tools are available i
 
 | Category | Available To | Tools |
 |----------|-------------|-------|
-| **execution** | All agents | `execute_shell`, `read_file`, `write_file` |
+| **execution** | All agents | `execute_shell`, `read_file`, `write_file`, `send_file` |
 | **research** | All agents | `search_web`, `fetch_url`, `skill` |
 | **orchestration** | Main agent + `full`-mode sub-sessions | `worker_delegation`, `task`, `append_memory`, `query_telemetry` |
 
@@ -82,6 +82,17 @@ Write content to a file, creating parent directories as needed.
 |-----------|------|----------|-------------|
 | `path` | string | yes | Absolute or relative file path |
 | `content` | string | yes | Text content to write |
+
+#### `send_file`
+
+Send a file to the user. Images are sent inline; other files as downloads. Frontend-agnostic: emits a `send_file` event on the EventBus; each frontend (Matrix, web) subscribes and handles delivery independently.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | yes | Absolute or relative path to the file |
+| `caption` | string | no | Optional caption or description |
+
+Returns: `status`, `path`, `filename`, `mime_type`, `file_size`
 
 ### Research Tools
 

--- a/wintermute/core/tool_schemas.py
+++ b/wintermute/core/tool_schemas.py
@@ -349,6 +349,25 @@ TOOL_SCHEMAS = [
         },
     ),
     _fn(
+        "send_file",
+        "Send a file to the user. The file must exist on disk. "
+        "Images are sent inline; other files as downloads.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the file to send.",
+                },
+                "caption": {
+                    "type": "string",
+                    "description": "Optional caption or description for the file.",
+                },
+            },
+            "required": ["path"],
+        },
+    ),
+    _fn(
         "fetch_url",
         "Fetch a web page and return it as plain text (HTML stripped).",
         {
@@ -378,6 +397,7 @@ TOOL_CATEGORIES: dict[str, str] = {
     "read_file":          "execution",
     "write_file":         "execution",
     "search_web":         "research",
+    "send_file":          "execution",
     "fetch_url":          "research",
     "worker_delegation":  "orchestration",
     "task":               "orchestration",

--- a/wintermute/interfaces/matrix_thread.py
+++ b/wintermute/interfaces/matrix_thread.py
@@ -253,7 +253,8 @@ class MatrixThread:
                  whisper_client=None,
                  whisper_model: str = "",
                  whisper_language: str = "",
-                 slash_handler=None) -> None:
+                 slash_handler=None,
+                 event_bus=None) -> None:
         self._cfg = config
         self._llm = llm_thread
         self._client: Optional[Client] = None
@@ -271,19 +272,18 @@ class MatrixThread:
         self._slash_handler = slash_handler
         # Kimi-Code client for interactive auth flow.
         self._kimi_client = kimi_client
+        # Subscribe to send_file events from the tool.
+        self._event_bus = event_bus
+        if event_bus is not None:
+            event_bus.subscribe("send_file", self._handle_send_file_event)
 
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
 
-    _SEND_FILE_RE = _re.compile(r"\[send_file:(/[^\]\s]+)\]")
-
     async def send_message(self, text: str, room_id: str = None,
                            _retries: int = 3, _delay: float = 2.0) -> None:
         """Send a message to a room.  Auto-encrypts if room has E2EE.
-
-        Any ``[send_file:/absolute/path]`` markers in *text* are extracted
-        and uploaded as separate file/image messages before the text is sent.
 
         Retries up to *_retries* times on transient failures so that
         system-event broadcasts (sub-session results) are not silently lost.
@@ -295,14 +295,8 @@ class MatrixThread:
             logger.warning("send_message called without room_id, dropping message")
             return
 
-        # Extract and send file markers before the text message.
-        file_paths = self._SEND_FILE_RE.findall(text)
-        for fpath in file_paths:
-            await self._send_file(fpath, room_id)
-        text = self._SEND_FILE_RE.sub("", text).strip()
-
-        if not text:
-            return  # nothing left after stripping markers
+        if not text.strip():
+            return
 
         last_exc: Optional[Exception] = None
         for attempt in range(1, _retries + 1):
@@ -332,6 +326,16 @@ class MatrixThread:
                 await asyncio.sleep(_delay * attempt)
         logger.error("Matrix send to %s failed after %d attempts: %s",
                      room_id, _retries, last_exc)
+
+    async def _handle_send_file_event(self, event) -> None:
+        """EventBus handler for ``send_file`` events emitted by the tool."""
+        data = event.data if hasattr(event, "data") else event
+        file_path = data.get("path", "")
+        thread_id = data.get("thread_id", "")
+        if not file_path or not thread_id:
+            logger.warning("send_file event missing path or thread_id: %s", data)
+            return
+        await self._send_file(file_path, thread_id)
 
     async def _send_file(self, file_path: str, room_id: str,
                          _retries: int = 3, _delay: float = 2.0) -> None:

--- a/wintermute/main.py
+++ b/wintermute/main.py
@@ -735,6 +735,7 @@ async def main() -> None:
             whisper_model=whisper_model,
             whisper_language=whisper_language,
             slash_handler=slash_handler,
+            event_bus=event_bus,
         )
     else:
         logger.info("Matrix not configured - skipping Matrix interface")

--- a/wintermute/tools/__init__.py
+++ b/wintermute/tools/__init__.py
@@ -29,7 +29,7 @@ from wintermute.core.tool_schemas import (  # noqa: F401 — re-exported
 )
 from wintermute.tools.task_tools import tool_task, _describe_schedule  # noqa: F401
 from wintermute.tools.memory_tools import tool_append_memory, tool_skill
-from wintermute.tools.io_tools import tool_execute_shell, tool_read_file, tool_write_file
+from wintermute.tools.io_tools import tool_execute_shell, tool_read_file, tool_write_file, tool_send_file
 from wintermute.tools.web_tools import tool_search_web, tool_fetch_url
 from wintermute.tools.session_tools import tool_worker_delegation, tool_query_telemetry
 
@@ -57,6 +57,7 @@ _DISPATCH: dict[str, Any] = {
     "execute_shell":      tool_execute_shell,
     "read_file":          tool_read_file,
     "write_file":         tool_write_file,
+    "send_file":          tool_send_file,
     "search_web":         tool_search_web,
     "fetch_url":          tool_fetch_url,
     "query_telemetry":    tool_query_telemetry,

--- a/wintermute/tools/io_tools.py
+++ b/wintermute/tools/io_tools.py
@@ -4,7 +4,10 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from wintermute.core.tool_deps import ToolDeps
 
 logger = logging.getLogger(__name__)
 
@@ -52,3 +55,39 @@ def tool_write_file(inputs: dict, **_kw) -> str:
         return json.dumps({"status": "ok", "path": str(path)})
     except OSError as exc:
         return json.dumps({"error": str(exc)})
+
+
+def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
+                   thread_id: Optional[str] = None, **_kw) -> str:
+    """Validate a file and emit a ``send_file`` event for frontends to handle."""
+    import mimetypes
+
+    path = Path(inputs["path"])
+    if not path.is_file():
+        return json.dumps({"error": f"File not found or not a regular file: {path}"})
+
+    mime_type = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+    file_size = path.stat().st_size
+    caption = inputs.get("caption", "")
+
+    if tool_deps and tool_deps.event_bus:
+        tool_deps.event_bus.emit(
+            "send_file",
+            path=str(path.resolve()),
+            filename=path.name,
+            mime_type=mime_type,
+            file_size=file_size,
+            caption=caption,
+            thread_id=thread_id or "",
+        )
+        logger.info("send_file: emitted event for %s (%s, %d bytes)", path.name, mime_type, file_size)
+        return json.dumps({
+            "status": "ok",
+            "path": str(path.resolve()),
+            "filename": path.name,
+            "mime_type": mime_type,
+            "file_size": file_size,
+        })
+
+    logger.warning("send_file: no event_bus available, file not delivered")
+    return json.dumps({"error": "No delivery channel available (event_bus not configured)"})


### PR DESCRIPTION
## Summary

- Adds a new `send_file` tool (category: `execution`) that validates a file and emits an EventBus `send_file` event
- Removes the fragile `[send_file:/path]` regex parsing from Matrix's `send_message` — Matrix now subscribes to the EventBus event instead
- Frontend-agnostic design: new frontends only need `event_bus.subscribe("send_file", handler)`
- Simplifies BASE_PROMPT by removing instructions already covered by tool schemas (ai_prompt scheduling details, skill CRUD action list, schedule syntax)

## Changes

| File | What |
|---|---|
| `wintermute/core/tool_schemas.py` | New `send_file` schema + category |
| `wintermute/tools/io_tools.py` | `tool_send_file()` implementation |
| `wintermute/tools/__init__.py` | Dispatch registration |
| `wintermute/interfaces/matrix_thread.py` | Remove regex parsing, add EventBus subscription |
| `wintermute/main.py` | Pass `event_bus` to MatrixThread |
| `data/prompts/BASE_PROMPT.txt` | Remove redundant instructions (~8 lines) |
| `docs/tools.md` | Document new tool |

## Test plan

- [ ] Verify LLM uses `send_file` tool when asked to send a file
- [ ] Verify file appears in Matrix chat (image or file message)
- [ ] Verify error handling: nonexistent file, missing event_bus
- [ ] Verify old `[send_file:]` markers in LLM output no longer cause side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)