### PR TITLE
feat: weak-model resilience for dreaming and memory writes

### DIFF
--- a/PLAN_WEAK_MODEL_RESILIENCE.md
+++ b/PLAN_WEAK_MODEL_RESILIENCE.md
@@ -154,9 +154,9 @@ New query functions:
 
 **`wintermute/infra/memory_store.py`**
 
-Add `exists(entry_id: str) -> bool` to both `LocalVectorStore` and `QdrantStore`:
-- LocalVectorStore: `SELECT 1 FROM local_vectors WHERE entry_id = ?`
-- QdrantStore: `qdrant_client.retrieve(ids=[entry_id])`
+Add `exists_batch(entry_ids: list[str]) -> set[str]` to both `LocalVectorStore` and `QdrantStore`:
+- LocalVectorStore: query `local_vectors` for all `entry_id` values in `entry_ids` (e.g., `WHERE entry_id IN (...)`) and return the set of found IDs.
+- QdrantStore: `qdrant_client.retrieve(ids=entry_ids)` and return the set of IDs that exist.
 
 ### Dreaming integration
 
@@ -187,7 +187,7 @@ quality_force_enable_phases: []     # Override auto-disable for specific phases,
 ```
 
 ### Risk notes
-- `exists()` calls should be batched where possible (collect all IDs, query once)
+- `exists_batch()` is already batched (collect all IDs, query once)
 - `quality_force_enable_phases` provides a manual override to re-enable phases
 
 ---
@@ -259,5 +259,5 @@ These demonstrate: merging prior summary with new info, superseding old informat
 | `wintermute/infra/memory_io.py` | 2 | New validation function + gate |
 | `wintermute/workers/dreaming.py` | 1, 3 | Validation functions + survival tracking |
 | `wintermute/infra/database.py` | 3 | New table + 4 query functions |
-| `wintermute/infra/memory_store.py` | 3 | New `exists()` method on both backends |
+| `wintermute/infra/memory_store.py` | 3 | New `exists_batch()` method on both backends |
 | `config.yaml.example` | 1, 2, 3 | New config keys documented |

--- a/PLAN_WEAK_MODEL_RESILIENCE.md
+++ b/PLAN_WEAK_MODEL_RESILIENCE.md
@@ -20,8 +20,10 @@ No graduated feature tiers. No keyword-based NL parsing.
 Add a validation function around line 95 (after helpers):
 
 ```python
-def _validate_dreaming_output(text: str, phase: str, parsed: dict, context: dict) -> tuple[bool, str]:
+def _validate_dreaming_output(text: str, phase: str, parsed: dict, context: dict, *, cfg: dict | None = None) -> tuple[bool, str]:
 ```
+
+Pass `cfg=cfg` from the caller to avoid redundant config file reads inside tight loops.
 
 #### Prediction validation (lines ~1036-1073, `_phase_prediction`):
 
@@ -52,7 +54,7 @@ Insert at line ~879 after `schema_text = parsed.get("schema", "").strip()`.
 #### Association validation (lines ~761-773, `_phase_association`):
 
 1. `text` must be >= 15 characters
-2. `source_indices` must reference valid indices within the seed set (reject if any index >= len(seed_texts))
+2. `source_indices` must reference valid indices within the seed set (reject if any index < 0 or >= len(seed_texts))
 3. `source_indices` must have >= 2 entries
 4. Reject if `text` is a near-substring of any single seed entry (>0.6 overlap ratio)
 
@@ -81,22 +83,22 @@ confidence_max_input_overlap: 0.7   # Reject outputs that parrot >70% of input
 
 **`wintermute/infra/memory_io.py`**
 
-Add `_validate_memory_entry(entry: str, cfg: dict) -> tuple[bool, str]` before `append_memory()` (around line 24).
+Add `_validate_memory_entry(entry: str) -> tuple[bool, str]` before `append_memory()` (around line 24). No config parameter — thresholds are hardcoded with sensible defaults to keep the function self-contained.
 
 #### Validation rules:
 
 1. **Minimum length:** `len(entry.strip()) < 10` → reject
 2. **Maximum length:** `len(entry.strip()) > 2000` → reject (model dumping conversation/system prompt)
 3. **JSON/code detection:** Reject if entry starts with `{` or `[` and is valid JSON (`json.loads` succeeds)
-4. **System prompt echo:** Reject if entry contains any 2+ of: `"you are"`, `"your task"`, `"return json"`, `"convergence protocol"`, `"system event"`, `"sub-session"` (case-insensitive). These indicate the model is echoing instructions.
-5. **Repetitive content:** Reject if any single word appears > 5 times (split whitespace, casefold, count). Catches looping hallucinations.
+4. **System prompt echo:** Reject if entry matches 3+ of a fixed phrase list (`"you are an ai"`, `"your task is"`, `"respond in json"`, `"convergence protocol"`, `"system prompt"`, `"sub-session"`, `"function calling"`) — case-insensitive. 3+ matches avoids false positives from coincidental mention of one phrase.
+5. **Repetitive content:** Reject if a single filtered word (len > 2) appears > 5 times AND makes up >= 20% of filtered tokens, and only when there are >= 20 filtered tokens total. This prevents false positives on longer legitimate text.
 6. **Encoding artifacts:** Reject if entry contains `\x00` or 3+ consecutive backslashes.
 
 In `append_memory()` at line ~45 (before `status = "ok"`):
 ```python
-valid, reason = _validate_memory_entry(entry, validation_cfg)
+valid, reason = _validate_memory_entry(entry)
 if not valid:
-    logger.warning("Memory entry rejected: %s (entry: %s)", reason, entry[:100])
+    logger.warning("Memory entry rejected: %s (entry: %.100s)", reason, entry)
     return memory_store.count(), "rejected"
 ```
 
@@ -104,16 +106,9 @@ The `"rejected"` status propagates to the tool response via `tool_append_memory`
 
 **Fail-open:** Wrap the entire validation in try/except. If validation itself throws, log the error and allow the write.
 
-### Config additions (`config.yaml.example`)
+### No new config keys for Feature 2.
 
-Under `memory_harvest`:
-```yaml
-validation:
-  min_length: 10
-  max_length: 2000
-  reject_json: true
-  reject_system_echoes: true
-```
+Thresholds are hardcoded. The validation is fail-open, transparent, and not intended to be tuned per-deployment.
 
 ### No new database tables.
 
@@ -146,9 +141,9 @@ CREATE TABLE IF NOT EXISTS dreaming_quality (
 New query functions:
 
 1. `record_dreaming_entries(phase_name: str, entry_ids: list[str]) -> None`
-2. `get_unchecked_dreaming_entries(phase_name: str) -> list[dict]` — rows where `survived_count IS NULL` and `cycle_timestamp` older than 24h
+2. `get_unchecked_dreaming_entries(phase_name: str, limit: int = 500) -> list[dict]` — rows where `survived_count IS NULL` and `cycle_timestamp` older than 24h, ordered oldest-first, bounded by `limit` to prevent unbounded backlogs
 3. `update_dreaming_survival(row_id: int, survived_count: int) -> None`
-4. `get_phase_survival_rate(phase_name: str, lookback_cycles: int) -> float | None` — `SUM(survived_count) / SUM(entries_count)` for last N checked cycles. Returns None if < 2 data points.
+4. `get_phase_survival_rate(phase_name: str, lookback_cycles: int) -> tuple[float, int] | None` — returns `(rate, count)` where `rate = SUM(survived_count) / SUM(entries_count)` and `count` is the number of checked cycles that contributed. Returns None if < 2 data points.
 
 ### Memory store changes
 
@@ -171,9 +166,9 @@ New function `_check_survival(cfg: dict) -> dict[str, bool]`:
 2. For each row, check which entry_ids still exist in memory_store
 3. Update survival count
 4. Compute survival rate
-5. Return `{phase_name: should_run}` — `False` if rate < threshold (default 0.3) over >= 3 cycles
+5. Return `{phase_name: should_run}` — `False` if rate < threshold (default 0.3) and the actual checked-cycle count (from `get_phase_survival_rate`) >= `quality_min_cycles`, or if rate == 0.0
 
-Call `_check_survival` at the beginning of `run_dream_cycle()` (around line 1178). Use the returned dict to skip phases. Log clearly when a phase is auto-disabled.
+Call `_check_survival` **after housekeeping phases** in `run_dream_cycle()`. Housekeeping deletions (dedup, contradiction, stale pruning) must run first so the survival check reflects real quality, not entries that were always going to be pruned. Use the returned dict to gate creative phases. Log clearly when a phase is auto-disabled.
 
 ### Config additions (`config.yaml.example`)
 

--- a/PLAN_WEAK_MODEL_RESILIENCE.md
+++ b/PLAN_WEAK_MODEL_RESILIENCE.md
@@ -1,0 +1,263 @@
+# Plan: Weak-Model Resilience Features
+
+Four features to improve Wintermute's reliability with small/local LLMs (9B class).
+No graduated feature tiers. No keyword-based NL parsing.
+
+**Implementation order:** Feature 4 → 2 → 1 → 3 (lowest risk first, most data-dependent last).
+
+---
+
+## Feature 1: Confidence Gating on Dreaming Output
+
+**Problem:** Creative phases (prediction, schema, association) trust the LLM's self-reported `"confidence"` field. A weak model claims `"high"` for garbage output. The only current check filters out `"low"` — it does not validate content coherence.
+
+**Approach:** Programmatic structural validators that run AFTER JSON parsing but BEFORE writing to memory store. These check measurable properties of the output, not the model's opinion of itself.
+
+### Files to modify
+
+**`wintermute/workers/dreaming.py`**
+
+Add a validation function around line 95 (after helpers):
+
+```python
+def _validate_dreaming_output(text: str, phase: str, parsed: dict, context: dict) -> tuple[bool, str]:
+```
+
+#### Prediction validation (lines ~1036-1073, `_phase_prediction`):
+
+1. `text` must be >= 20 characters (reject trivially short outputs)
+2. `text` must not be a near-duplicate of the input activity summary (character overlap ratio > 0.7 means the model is parroting input)
+3. For `temporal` type: structured suffix `||hours=...||` must have valid hour ranges (0-23) and valid day abbreviations. If malformed, downgrade to `behavioral` type rather than rejecting.
+4. Reject if `text` contains 3+ consecutive identical words (common small-model hallucination)
+5. Reject if `text` is identical (case-insensitive, stripped) to an existing prediction — fetch existing predictions via `memory_store.get_by_source("dreaming_prediction", 50, False)` before the loop, build a set of normalized texts.
+
+Insert at line ~1041 before the `if text:` check:
+
+```python
+valid, reason = _validate_dreaming_output(text, "prediction", pred, {"existing": existing_texts})
+if not valid:
+    logger.info("Dreaming prediction rejected: %s", reason)
+    continue
+```
+
+#### Schema validation (lines ~874-907, `_phase_schema`):
+
+1. `schema_text` must be >= 15 characters
+2. `schema_text` must not be a substring of any single cluster member (the model should generalize, not copy)
+3. If `replaces_entries` is True but `confidence` is not `"high"`, force `replaces_entries = False` (programmatic override)
+4. Reject if `schema_text` contains JSON fragments or markdown headers (`{"`, `##`, triple backticks — signs the model returned formatting instead of content)
+
+Insert at line ~879 after `schema_text = parsed.get("schema", "").strip()`.
+
+#### Association validation (lines ~761-773, `_phase_association`):
+
+1. `text` must be >= 15 characters
+2. `source_indices` must reference valid indices within the seed set (reject if any index >= len(seed_texts))
+3. `source_indices` must have >= 2 entries
+4. Reject if `text` is a near-substring of any single seed entry (>0.6 overlap ratio)
+
+Insert at line ~766 after current confidence check.
+
+### Config additions (`config.yaml.example`)
+
+Under `memory.dreaming`:
+```yaml
+# ── Confidence Gating ──
+confidence_min_text_length: 20      # Reject dreaming outputs shorter than this
+confidence_max_input_overlap: 0.7   # Reject outputs that parrot >70% of input
+```
+
+### No new database tables. No new dependencies.
+
+---
+
+## Feature 2: Memory Write Validation
+
+**Problem:** `append_memory` (used by harvest and direct AI calls) has no content validation. Weak models write garbage: single words, JSON fragments, system prompt echoes, looping hallucinations.
+
+**Approach:** Validation gate in `memory_io.append_memory()` — the single chokepoint for all memory writes.
+
+### Files to modify
+
+**`wintermute/infra/memory_io.py`**
+
+Add `_validate_memory_entry(entry: str, cfg: dict) -> tuple[bool, str]` before `append_memory()` (around line 24).
+
+#### Validation rules:
+
+1. **Minimum length:** `len(entry.strip()) < 10` → reject
+2. **Maximum length:** `len(entry.strip()) > 2000` → reject (model dumping conversation/system prompt)
+3. **JSON/code detection:** Reject if entry starts with `{` or `[` and is valid JSON (`json.loads` succeeds)
+4. **System prompt echo:** Reject if entry contains any 2+ of: `"you are"`, `"your task"`, `"return json"`, `"convergence protocol"`, `"system event"`, `"sub-session"` (case-insensitive). These indicate the model is echoing instructions.
+5. **Repetitive content:** Reject if any single word appears > 5 times (split whitespace, casefold, count). Catches looping hallucinations.
+6. **Encoding artifacts:** Reject if entry contains `\x00` or 3+ consecutive backslashes.
+
+In `append_memory()` at line ~45 (before `status = "ok"`):
+```python
+valid, reason = _validate_memory_entry(entry, validation_cfg)
+if not valid:
+    logger.warning("Memory entry rejected: %s (entry: %s)", reason, entry[:100])
+    return memory_store.count(), "rejected"
+```
+
+The `"rejected"` status propagates to the tool response via `tool_append_memory` in `wintermute/tools/memory_tools.py` — no changes needed there.
+
+**Fail-open:** Wrap the entire validation in try/except. If validation itself throws, log the error and allow the write.
+
+### Config additions (`config.yaml.example`)
+
+Under `memory_harvest`:
+```yaml
+validation:
+  min_length: 10
+  max_length: 2000
+  reject_json: true
+  reject_system_echoes: true
+```
+
+### No new database tables.
+
+---
+
+## Feature 3: Dreaming Quality Metrics
+
+**Problem:** No feedback loop to detect when dreaming phases degrade memory quality. Bad schemas or noisy associations accumulate with no mechanism to detect the pattern and disable the offending phase.
+
+**Approach:** Track dreaming output survival rate. After each cycle, record what was added. In the next cycle, check how many previous additions still exist (weren't deleted by dedup, user, or contradiction resolution). If survival rate drops below threshold over N cycles, auto-disable the phase.
+
+### Database schema
+
+**`wintermute/infra/database.py`**
+
+New table in `run_migrations()` (after `dreaming_state`, around line 197):
+
+```sql
+CREATE TABLE IF NOT EXISTS dreaming_quality (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_timestamp REAL NOT NULL,
+    phase_name      TEXT NOT NULL,
+    entry_ids       TEXT NOT NULL,    -- JSON array of memory store IDs added
+    entries_count   INTEGER NOT NULL,
+    survived_count  INTEGER,          -- filled in next cycle
+    checked_at      REAL              -- when survival was checked
+);
+```
+
+New query functions:
+
+1. `record_dreaming_entries(phase_name: str, entry_ids: list[str]) -> None`
+2. `get_unchecked_dreaming_entries(phase_name: str) -> list[dict]` — rows where `survived_count IS NULL` and `cycle_timestamp` older than 24h
+3. `update_dreaming_survival(row_id: int, survived_count: int) -> None`
+4. `get_phase_survival_rate(phase_name: str, lookback_cycles: int) -> float | None` — `SUM(survived_count) / SUM(entries_count)` for last N checked cycles. Returns None if < 2 data points.
+
+### Memory store changes
+
+**`wintermute/infra/memory_store.py`**
+
+Add `exists(entry_id: str) -> bool` to both `LocalVectorStore` and `QdrantStore`:
+- LocalVectorStore: `SELECT 1 FROM local_vectors WHERE entry_id = ?`
+- QdrantStore: `qdrant_client.retrieve(ids=[entry_id])`
+
+### Dreaming integration
+
+**`wintermute/workers/dreaming.py`**
+
+In each creative phase function (`_phase_association`, `_phase_schema`, `_phase_prediction`):
+- Collect returned `entry_id` from each `memory_store.add()` call
+- After the loop: `database.record_dreaming_entries(phase_name, collected_ids)`
+
+New function `_check_survival(cfg: dict) -> dict[str, bool]`:
+1. For each phase ("association", "schema", "prediction"), fetch unchecked rows
+2. For each row, check which entry_ids still exist in memory_store
+3. Update survival count
+4. Compute survival rate
+5. Return `{phase_name: should_run}` — `False` if rate < threshold (default 0.3) over >= 3 cycles
+
+Call `_check_survival` at the beginning of `run_dream_cycle()` (around line 1178). Use the returned dict to skip phases. Log clearly when a phase is auto-disabled.
+
+### Config additions (`config.yaml.example`)
+
+Under `memory.dreaming`:
+```yaml
+# ── Quality Metrics ──
+quality_survival_threshold: 0.3     # Auto-disable creative phases below this survival rate
+quality_min_cycles: 3               # Require N cycles before auto-disabling
+quality_lookback_cycles: 5          # Compute survival over last N cycles
+quality_force_enable_phases: []     # Override auto-disable for specific phases, e.g. ["association"]
+```
+
+### Risk notes
+- `exists()` calls should be batched where possible (collect all IDs, query once)
+- `quality_force_enable_phases` provides a manual override to re-enable phases
+
+---
+
+## Feature 4: Compaction Prompt Examples
+
+**Problem:** `data/prompts/COMPACTION_PROMPT.txt` has zero few-shot examples. Small models produce much better structured summaries when given concrete examples.
+
+**Approach:** Add 2 compact examples directly into the prompt template. No code changes needed.
+
+### File to modify
+
+**`data/prompts/COMPACTION_PROMPT.txt`**
+
+Insert between the formatting instructions (line ~17) and the `{history}` placeholder:
+
+**Example 1 (simple merge):**
+```
+--- example input ---
+[PRIOR SUMMARY]
+- User is developing a Python CLI tool called "netwatch"
+
+[NEW MESSAGES]
+USER: Can you add a --timeout flag to the CLI?
+ASSISTANT: Done. Added --timeout to netwatch/cli.py with a default of 30 seconds.
+USER: Perfect, make it 60 seconds default instead.
+ASSISTANT: Updated the default timeout to 60 seconds.
+
+--- example output ---
+**netwatch CLI tool**
+- User is developing a Python CLI tool called "netwatch"
+- Added --timeout flag to netwatch/cli.py (default: 60 seconds)
+```
+
+**Example 2 (prior summary supersession):**
+```
+--- example input ---
+[PRIOR SUMMARY]
+- User prefers dark mode in all applications
+- Working on a React dashboard for inventory management
+- Database is PostgreSQL 15 on localhost
+
+[NEW MESSAGES]
+USER: Actually let's switch to MySQL, the hosting provider doesn't support Postgres.
+ASSISTANT: I've updated the database connection in config.ts to use MySQL.
+
+--- example output ---
+**User preferences**
+- Prefers dark mode in all applications
+
+**Inventory dashboard (React)**
+- Switched from PostgreSQL to MySQL (hosting constraint)
+- Database connection updated in config.ts
+```
+
+These demonstrate: merging prior summary with new info, superseding old information, grouped bulleted format, concise output.
+
+**Token impact:** ~150 tokens added per compaction call. Negligible given that compaction already sends the full conversation history.
+
+### No code changes needed. The `{history}` placeholder remains at the end.
+
+---
+
+## Summary of all changes
+
+| File | Feature(s) | Type |
+|---|---|---|
+| `data/prompts/COMPACTION_PROMPT.txt` | 4 | Prompt-only |
+| `wintermute/infra/memory_io.py` | 2 | New validation function + gate |
+| `wintermute/workers/dreaming.py` | 1, 3 | Validation functions + survival tracking |
+| `wintermute/infra/database.py` | 3 | New table + 4 query functions |
+| `wintermute/infra/memory_store.py` | 3 | New `exists()` method on both backends |
+| `config.yaml.example` | 1, 2, 3 | New config keys documented |

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -636,6 +636,18 @@ memory:
     prediction_proactive_cooldown_hours: 4 # Min hours between proactive fires per prediction
     # proactive_target_thread_id: "default"  # Thread to deliver proactive results to (default: main thread)
 
+    # ── Confidence Gating (weak-model resilience) ──
+    # Programmatic validators reject garbage dreaming outputs before memory writes.
+    confidence_min_text_length: 20        # Reject dreaming outputs shorter than this
+    confidence_max_input_overlap: 0.7     # Reject outputs that parrot >70% of input
+
+    # ── Quality Metrics ──
+    # Track dreaming output survival rates; auto-disable phases with high rejection.
+    quality_survival_threshold: 0.3       # Auto-disable creative phases below this survival rate
+    quality_min_cycles: 3                 # Require N checked cycles before auto-disabling
+    quality_lookback_cycles: 5            # Compute survival over last N cycles
+    quality_force_enable_phases: []       # Override auto-disable, e.g. ["association"]
+
   # Qdrant connection (required for qdrant backend only).
   # api_key is optional — only needed for Qdrant Cloud or instances
   # configured with authentication. Leave empty for local unauthenticated.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -642,7 +642,7 @@ memory:
     confidence_max_input_overlap: 0.7     # Reject outputs that parrot >70% of input
 
     # ── Quality Metrics ──
-    # Track dreaming output survival rates; auto-disable phases with high rejection.
+    # Track dreaming output survival rates; auto-disable phases with low survival.
     quality_survival_threshold: 0.3       # Auto-disable creative phases below this survival rate
     quality_min_cycles: 3                 # Require N checked cycles before auto-disabling
     quality_lookback_cycles: 5            # Compute survival over last N cycles

--- a/data/prompts/COMPACTION_PROMPT.txt
+++ b/data/prompts/COMPACTION_PROMPT.txt
@@ -16,5 +16,38 @@ Omit:
 
 Format as a concise bulleted list grouped by topic. Do not add commentary.
 
+--- example input ---
+[PRIOR SUMMARY]
+- User is developing a Python CLI tool called "netwatch"
+
+[NEW MESSAGES]
+USER: Can you add a --timeout flag to the CLI?
+ASSISTANT: Done. Added --timeout to netwatch/cli.py with a default of 30 seconds.
+USER: Perfect, make it 60 seconds default instead.
+ASSISTANT: Updated the default timeout to 60 seconds.
+
+--- example output ---
+**netwatch CLI tool**
+- User is developing a Python CLI tool called "netwatch"
+- Added --timeout flag to netwatch/cli.py (default: 60 seconds)
+
+--- example input ---
+[PRIOR SUMMARY]
+- User prefers dark mode in all applications
+- Working on a React dashboard for inventory management
+- Database is PostgreSQL 15 on localhost
+
+[NEW MESSAGES]
+USER: Actually let's switch to MySQL, the hosting provider doesn't support Postgres.
+ASSISTANT: I've updated the database connection in config.ts to use MySQL.
+
+--- example output ---
+**User preferences**
+- Prefers dark mode in all applications
+
+**Inventory dashboard (React)**
+- Switched from PostgreSQL to MySQL (hosting constraint)
+- Database connection updated in config.ts
+
 --- conversation history ---
 {history}

--- a/uv.lock
+++ b/uv.lock
@@ -1703,7 +1703,7 @@ wheels = [
 
 [[package]]
 name = "wintermute"
-version = "0.13.0a0"
+version = "0.13.1a0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/wintermute/infra/database.py
+++ b/wintermute/infra/database.py
@@ -200,6 +200,15 @@ def run_migrations(conn: sqlite3.Connection) -> None:
             config_json TEXT NOT NULL,
             updated_at  REAL NOT NULL
         );
+        CREATE TABLE IF NOT EXISTS dreaming_quality (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            cycle_timestamp REAL NOT NULL,
+            phase_name      TEXT NOT NULL,
+            entry_ids       TEXT NOT NULL,
+            entries_count   INTEGER NOT NULL,
+            survived_count  INTEGER,
+            checked_at      REAL
+        );
         CREATE TABLE IF NOT EXISTS prediction_accuracy (
             prediction_id   TEXT PRIMARY KEY,
             source_text     TEXT,
@@ -1130,6 +1139,73 @@ def update_dreaming_phase_state(
             (phase_name, now, items_processed, outcome_summary),
         )
         conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Dreaming Quality Metrics
+# ---------------------------------------------------------------------------
+
+def record_dreaming_entries(phase_name: str, entry_ids: list[str]) -> None:
+    """Record which memory entries were created by a dreaming phase."""
+    import json as _json
+    now = time.time()
+    with _connect() as conn:
+        conn.execute(
+            "INSERT INTO dreaming_quality "
+            "(cycle_timestamp, phase_name, entry_ids, entries_count) "
+            "VALUES (?, ?, ?, ?)",
+            (now, phase_name, _json.dumps(entry_ids), len(entry_ids)),
+        )
+        conn.commit()
+
+
+def get_unchecked_dreaming_entries(phase_name: str) -> list[dict]:
+    """Return rows where survival has not yet been checked (>24h old)."""
+    cutoff = time.time() - 86400
+    with _connect() as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT id, cycle_timestamp, entry_ids, entries_count "
+            "FROM dreaming_quality "
+            "WHERE phase_name = ? AND survived_count IS NULL "
+            "AND cycle_timestamp < ?",
+            (phase_name, cutoff),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def update_dreaming_survival(row_id: int, survived_count: int) -> None:
+    """Update the survival count for a dreaming quality row."""
+    now = time.time()
+    with _connect() as conn:
+        conn.execute(
+            "UPDATE dreaming_quality SET survived_count = ?, checked_at = ? "
+            "WHERE id = ?",
+            (survived_count, now, row_id),
+        )
+        conn.commit()
+
+
+def get_phase_survival_rate(
+    phase_name: str, lookback_cycles: int = 5,
+) -> float | None:
+    """Compute survival rate for a phase over the last N checked cycles.
+
+    Returns ``None`` if fewer than 2 data points are available.
+    """
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT SUM(survived_count), SUM(entries_count), COUNT(*) "
+            "FROM ("
+            "  SELECT survived_count, entries_count FROM dreaming_quality "
+            "  WHERE phase_name = ? AND survived_count IS NOT NULL "
+            "  ORDER BY cycle_timestamp DESC LIMIT ?"
+            ")",
+            (phase_name, lookback_cycles),
+        ).fetchone()
+    if not row or row[2] < 2 or not row[1]:
+        return None
+    return row[0] / row[1]
 
 
 def count_memories_added_since(since: float) -> int:

--- a/wintermute/infra/database.py
+++ b/wintermute/infra/database.py
@@ -1196,6 +1196,20 @@ def update_dreaming_survival(row_id: int, survived_count: int) -> None:
         conn.commit()
 
 
+def batch_update_dreaming_survival(updates: list[tuple[int, int]]) -> None:
+    """Update survival counts for multiple dreaming quality rows in one transaction."""
+    if not updates:
+        return
+    now = time.time()
+    with _connect() as conn:
+        conn.executemany(
+            "UPDATE dreaming_quality SET survived_count = ?, checked_at = ? "
+            "WHERE id = ?",
+            [(survived_count, now, row_id) for row_id, survived_count in updates],
+        )
+        conn.commit()
+
+
 def get_phase_survival_rate(
     phase_name: str, lookback_cycles: int = 5,
 ) -> tuple[float, int] | None:

--- a/wintermute/infra/database.py
+++ b/wintermute/infra/database.py
@@ -1188,10 +1188,12 @@ def update_dreaming_survival(row_id: int, survived_count: int) -> None:
 
 def get_phase_survival_rate(
     phase_name: str, lookback_cycles: int = 5,
-) -> float | None:
+) -> tuple[float, int] | None:
     """Compute survival rate for a phase over the last N checked cycles.
 
-    Returns ``None`` if fewer than 2 data points are available.
+    Returns ``(rate, count)`` where *count* is the number of checked cycles
+    that contributed to *rate*, or ``None`` if fewer than 2 data points are
+    available.
     """
     with _connect() as conn:
         row = conn.execute(
@@ -1205,7 +1207,7 @@ def get_phase_survival_rate(
         ).fetchone()
     if not row or row[2] < 2 or not row[1]:
         return None
-    return row[0] / row[1]
+    return row[0] / row[1], row[2]
 
 
 def count_memories_added_since(since: float) -> int:

--- a/wintermute/infra/database.py
+++ b/wintermute/infra/database.py
@@ -1159,8 +1159,16 @@ def record_dreaming_entries(phase_name: str, entry_ids: list[str]) -> None:
         conn.commit()
 
 
-def get_unchecked_dreaming_entries(phase_name: str) -> list[dict]:
-    """Return rows where survival has not yet been checked (>24h old)."""
+def get_unchecked_dreaming_entries(
+    phase_name: str, limit: int = 500,
+) -> list[dict]:
+    """Return rows where survival has not yet been checked (>24h old).
+
+    Results are ordered oldest-first so that long backlogs (e.g. after
+    extended downtime) are drained incrementally rather than all at once.
+    *limit* bounds the number of rows returned per call to prevent excessive
+    memory use and backend round-trips when the backlog is large.
+    """
     cutoff = time.time() - 86400
     with _connect() as conn:
         conn.row_factory = sqlite3.Row
@@ -1168,8 +1176,10 @@ def get_unchecked_dreaming_entries(phase_name: str) -> list[dict]:
             "SELECT id, cycle_timestamp, entry_ids, entries_count "
             "FROM dreaming_quality "
             "WHERE phase_name = ? AND survived_count IS NULL "
-            "AND cycle_timestamp < ?",
-            (phase_name, cutoff),
+            "AND cycle_timestamp < ? "
+            "ORDER BY cycle_timestamp ASC "
+            "LIMIT ?",
+            (phase_name, cutoff, limit),
         ).fetchall()
     return [dict(r) for r in rows]
 

--- a/wintermute/infra/memory_io.py
+++ b/wintermute/infra/memory_io.py
@@ -54,12 +54,16 @@ def _validate_memory_entry(entry: str) -> tuple[bool, str]:
         if matches >= 3:
             return False, "system_echo"
 
-        # --- repetitive content (any word > 5 occurrences) ---
-        words = lower.split()
-        if words:
+        # --- repetitive content (single word dominates the text) ---
+        # Filter out tokens ≤2 chars to avoid false-positives from stopwords.
+        # Require ≥20 filtered tokens before applying, and flag only when a
+        # single word both appears >5 times AND makes up ≥20% of the text.
+        tokens = re.findall(r"\b\w+\b", lower)
+        filtered = [t for t in tokens if len(t) > 2]
+        if len(filtered) >= 20:
             from collections import Counter
-            counts = Counter(words)
-            if counts.most_common(1)[0][1] > 5:
+            top_word, top_count = Counter(filtered).most_common(1)[0]
+            if top_count > 5 and top_count / len(filtered) >= 0.2:
                 return False, "repetitive"
 
         # --- encoding artifacts ---

--- a/wintermute/infra/memory_io.py
+++ b/wintermute/infra/memory_io.py
@@ -98,15 +98,16 @@ def append_memory(
     - Deferred ``memory.appended`` via done-callback on timeout.
 
     Returns ``(total_entry_count, status)`` where *status* is one of
-    ``"ok"``, ``"pending"`` (timeout — coroutine still in-flight), or
-    ``"fallback"`` (dedup failed, plain add used).
+    ``"ok"``, ``"pending"`` (timeout — coroutine still in-flight),
+    ``"rejected"`` (entry failed validation gate), or ``"fallback"``
+    (dedup failed, plain add used).
     """
     from wintermute.infra import memory_store
 
     valid, reason = _validate_memory_entry(entry)
     if not valid:
         logger.warning("Memory entry rejected: %s (entry: %.100s)", reason, entry)
-        return 0, "rejected"
+        return memory_store.count(), "rejected"
 
     status = "ok"
     _entry_preview = entry[:200]

--- a/wintermute/infra/memory_io.py
+++ b/wintermute/infra/memory_io.py
@@ -5,10 +5,71 @@ Memory entries are stored exclusively in the vector memory store.
 The deprecated MEMORIES.txt flat file has been removed.
 """
 
+import json
 import logging
+import re
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Phrases that indicate the model is echoing system/infrastructure instructions.
+_SYSTEM_ECHO_PHRASES = (
+    "you are an ai",
+    "your task is",
+    "respond in json",
+    "convergence protocol",
+    "system prompt",
+    "sub-session",
+    "function calling",
+)
+
+
+def _validate_memory_entry(entry: str) -> tuple[bool, str]:
+    """Programmatic quality gate for memory writes.
+
+    Returns ``(True, "")`` when the entry is acceptable, or
+    ``(False, reason)`` when it should be rejected.  Fail-open: if
+    validation itself throws, the entry is allowed through.
+    """
+    try:
+        text = entry.strip()
+
+        # --- length bounds ---
+        if len(text) < 10:
+            return False, "too_short"
+        if len(text) > 2000:
+            return False, "too_long"
+
+        # --- raw JSON / code dump ---
+        if text[0] in ("{", "["):
+            try:
+                json.loads(text)
+                return False, "raw_json"
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        # --- system prompt echo (3+ phrase matches) ---
+        lower = text.lower()
+        matches = sum(1 for p in _SYSTEM_ECHO_PHRASES if p in lower)
+        if matches >= 3:
+            return False, "system_echo"
+
+        # --- repetitive content (any word > 5 occurrences) ---
+        words = lower.split()
+        if words:
+            from collections import Counter
+            counts = Counter(words)
+            if counts.most_common(1)[0][1] > 5:
+                return False, "repetitive"
+
+        # --- encoding artifacts ---
+        if "\x00" in text or re.search(r"\\{3,}", text):
+            return False, "encoding_artifacts"
+
+    except Exception:
+        logger.debug("Memory validation error (fail-open)", exc_info=True)
+
+    return True, ""
 
 
 def read_text_safe(path: Path, default: str = "") -> str:
@@ -41,6 +102,11 @@ def append_memory(
     ``"fallback"`` (dedup failed, plain add used).
     """
     from wintermute.infra import memory_store
+
+    valid, reason = _validate_memory_entry(entry)
+    if not valid:
+        logger.warning("Memory entry rejected: %s (entry: %.100s)", reason, entry)
+        return 0, "rejected"
 
     status = "ok"
     _entry_preview = entry[:200]

--- a/wintermute/infra/memory_store.py
+++ b/wintermute/infra/memory_store.py
@@ -146,17 +146,23 @@ class LocalVectorBackend:
         """Return the subset of *entry_ids* that still exist in the store."""
         if not entry_ids:
             return set()
-        placeholders = ",".join("?" for _ in entry_ids)
+        # SQLite has a ~999-variable limit per query; chunk to stay within it.
+        chunk_size = 900
+        existing: set[str] = set()
         with self._lock:
             conn = self._connect()
             try:
-                rows = conn.execute(
-                    f"SELECT entry_id FROM local_vectors WHERE entry_id IN ({placeholders})",
-                    entry_ids,
-                ).fetchall()
+                for i in range(0, len(entry_ids), chunk_size):
+                    chunk = entry_ids[i : i + chunk_size]
+                    placeholders = ",".join("?" for _ in chunk)
+                    rows = conn.execute(
+                        f"SELECT entry_id FROM local_vectors WHERE entry_id IN ({placeholders})",
+                        chunk,
+                    ).fetchall()
+                    existing.update(r[0] for r in rows)
             finally:
                 conn.close()
-        return {r[0] for r in rows}
+        return existing
 
     def search(self, query: str, top_k: int, threshold: float,
                *, bump_access: bool = True) -> list[dict]:

--- a/wintermute/infra/memory_store.py
+++ b/wintermute/infra/memory_store.py
@@ -59,6 +59,7 @@ class MemoryBackend(Protocol):
     def get_by_source(self, source: str, limit: int = 50, bump_access: bool = True) -> list[dict]: ...
     def track_access(self, entry_ids: list[str]) -> None: ...
     def promote_source(self, entry_id: str, new_source: str) -> None: ...
+    def exists_batch(self, entry_ids: list[str]) -> set[str]: ...
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +141,22 @@ class LocalVectorBackend:
                 conn.close()
         _log_interaction(t0, "local_vector_add", entry[:200], f"id={eid}", llm="local_vector")
         return eid
+
+    def exists_batch(self, entry_ids: list[str]) -> set[str]:
+        """Return the subset of *entry_ids* that still exist in the store."""
+        if not entry_ids:
+            return set()
+        placeholders = ",".join("?" for _ in entry_ids)
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    f"SELECT entry_id FROM local_vectors WHERE entry_id IN ({placeholders})",
+                    entry_ids,
+                ).fetchall()
+            finally:
+                conn.close()
+        return {r[0] for r in rows}
 
     def search(self, query: str, top_k: int, threshold: float,
                *, bump_access: bool = True) -> list[dict]:
@@ -676,6 +693,19 @@ class QdrantBackend:
         _log_interaction(t0, "qdrant_add", entry[:200], f"id={eid}", llm="qdrant")
         return eid
 
+    def exists_batch(self, entry_ids: list[str]) -> set[str]:
+        """Return the subset of *entry_ids* that still exist in Qdrant."""
+        if not entry_ids:
+            return set()
+        with self._lock:
+            pts = self._client.retrieve(
+                collection_name=self._collection,
+                ids=entry_ids,
+                with_payload=False,
+                with_vectors=False,
+            )
+        return {str(p.id) for p in pts}
+
     def search(self, query: str, top_k: int, threshold: float,
                *, bump_access: bool = True) -> list[dict]:
         vectors = _embed([query], self._embed_cfg, task="query")
@@ -1187,6 +1217,11 @@ def get_stale(max_age_days: int, min_access: int) -> list[dict]:
 
 def bulk_delete(entry_ids: list[str]) -> int:
     return _backend.bulk_delete(entry_ids)
+
+
+def exists_batch(entry_ids: list[str]) -> set[str]:
+    """Return the subset of *entry_ids* that still exist in the store."""
+    return _backend.exists_batch(entry_ids)
 
 
 def get_dreaming_config() -> dict:

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -133,6 +133,96 @@ async def _consolidate(pool: "BackendPool",
 
 
 
+def _validate_dreaming_output(
+    text: str, phase: str, parsed: dict, context: dict,
+) -> tuple[bool, str]:
+    """Programmatic structural validation for creative-phase outputs.
+
+    Returns ``(True, "")`` on pass or ``(False, reason)`` on reject.
+    Fail-open: exceptions inside validation allow the entry through.
+    """
+    try:
+        # ── Common checks ──────────────────────────────────────────
+        min_len = 20 if phase == "prediction" else 15
+        if len(text) < min_len:
+            return False, f"too_short ({len(text)}<{min_len})"
+
+        # 3+ consecutive identical words → hallucination loop
+        words = text.split()
+        for i in range(len(words) - 2):
+            if words[i] == words[i + 1] == words[i + 2]:
+                return False, "consecutive_repeat"
+
+        # JSON / markdown fragments in output
+        if '{"' in text or "```" in text or text.lstrip().startswith("##"):
+            return False, "formatting_fragment"
+
+        # ── Association-specific ───────────────────────────────────
+        if phase == "association":
+            source_indices = parsed.get("source_indices", [])
+            seed_texts = context.get("seed_texts", [])
+            if seed_texts and isinstance(source_indices, list):
+                if len(source_indices) < 2:
+                    return False, "too_few_sources"
+                if any(
+                    not isinstance(idx, int) or idx >= len(seed_texts)
+                    for idx in source_indices
+                ):
+                    return False, "invalid_source_index"
+            # Near-substring of a single seed → model copied input
+            if seed_texts:
+                from difflib import SequenceMatcher
+                for st in seed_texts:
+                    if st and SequenceMatcher(None, text.lower(), st.lower()).ratio() > 0.6:
+                        return False, "near_copy_of_seed"
+
+        # ── Schema-specific ────────────────────────────────────────
+        elif phase == "schema":
+            cluster_texts = context.get("cluster_texts", [])
+            # Schema should generalise, not copy a single member
+            for ct in cluster_texts:
+                if ct and text.strip().lower() in ct.lower():
+                    return False, "substring_of_cluster_member"
+            # Force-downgrade replaces if confidence isn't high
+            if parsed.get("replaces_entries") and parsed.get("confidence") != "high":
+                parsed["replaces_entries"] = False
+
+        # ── Prediction-specific ────────────────────────────────────
+        elif phase == "prediction":
+            # Input-parrot detection
+            activity = context.get("activity_summary", "")
+            if activity:
+                from difflib import SequenceMatcher
+                if SequenceMatcher(None, text.lower(), activity.lower()).ratio() > 0.7:
+                    return False, "parrots_input"
+            # Duplicate detection
+            existing = context.get("existing_texts", set())
+            if text.strip().lower() in existing:
+                return False, "duplicate_prediction"
+            # Temporal suffix validation
+            pred_type = parsed.get("type", "behavioral")
+            if pred_type == "temporal" and "||" in text:
+                import re as _re
+                hour_match = _re.findall(r'\|\|hours?=([\d,\-]+)\|\|', text)
+                day_match = _re.findall(r'\|\|days?=([\w,\-]+)\|\|', text)
+                valid_days = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
+                malformed = False
+                for hm in hour_match:
+                    for h in hm.replace("-", ",").split(","):
+                        if h and (not h.isdigit() or not (0 <= int(h) <= 23)):
+                            malformed = True
+                for dm in day_match:
+                    for d in dm.split(","):
+                        if d.strip().lower() not in valid_days:
+                            malformed = True
+                if malformed:
+                    parsed["type"] = "behavioral"  # downgrade, don't reject
+    except Exception:
+        logger.debug("Dreaming output validation error (fail-open)", exc_info=True)
+
+    return True, ""
+
+
 def _load_dreaming_config() -> dict:
     """Load dreaming-specific config from config.yaml with defaults."""
     defaults = {
@@ -759,6 +849,7 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
             return result
 
         insights = parsed.get("insights", [])
+        collected_ids: list[str] = []
         for insight in insights:
             if insights_created >= max_insights:
                 break
@@ -766,12 +857,23 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
             if confidence not in ("high", "medium"):
                 continue
             text = insight.get("text", "").strip()
+            valid, reason = _validate_dreaming_output(
+                text, "association", insight, {"seed_texts": seed_texts},
+            )
+            if not valid:
+                logger.info("Dreaming association rejected: %s", reason)
+                continue
             if text:
-                await asyncio.to_thread(
+                eid = await asyncio.to_thread(
                     memory_store.add, text, None, "dreaming_association"
                 )
+                collected_ids.append(eid)
                 insights_created += 1
                 logger.info("Dreaming association insight: %s", text[:100])
+        if collected_ids:
+            await database.async_call(
+                database.record_dreaming_entries, "association", collected_ids,
+            )
     except Exception:  # noqa: BLE001
         logger.exception("Dreaming: association phase LLM failed")
         result.error = "LLM call failed"
@@ -842,6 +944,7 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
     schema_prompt = prompt_loader.load("DREAM_SCHEMA_PROMPT.txt")
     max_clusters = cfg["schema_max_clusters"]
     schemas_formed = 0
+    schema_collected_ids: list[str] = []
 
     # Sort clusters by size (largest first), cap at max.
     clusters = sorted(sim_data.schema_clusters, key=len, reverse=True)[:max_clusters]
@@ -881,10 +984,19 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
             if confidence not in ("high", "medium"):
                 continue
 
+            valid, reason = _validate_dreaming_output(
+                schema_text, "schema", parsed,
+                {"cluster_texts": cluster_texts},
+            )
+            if not valid:
+                logger.info("Dreaming schema rejected: %s", reason)
+                continue
+
             # Store the schema.
-            await asyncio.to_thread(
+            eid = await asyncio.to_thread(
                 memory_store.add, schema_text, None, "dreaming_schema"
             )
+            schema_collected_ids.append(eid)
             schemas_formed += 1
             logger.info("Dreaming schema: %s (replaces=%s)",
                         schema_text[:100], replaces)
@@ -908,6 +1020,10 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
             logger.debug("Dreaming: schema extraction failed for cluster",
                          exc_info=True)
 
+    if schema_collected_ids:
+        await database.async_call(
+            database.record_dreaming_entries, "schema", schema_collected_ids,
+        )
     result.items_processed = schemas_formed
     result.summary = f"formed {schemas_formed} schemas from {len(clusters)} clusters"
     await database.async_call(
@@ -1033,7 +1149,16 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
         parsed = parse_json_from_llm(raw, dict)
         predictions = parsed.get("predictions", [])
 
+        # Pre-fetch existing prediction texts for duplicate detection.
+        _existing_raw = await asyncio.to_thread(
+            memory_store.get_by_source, "dreaming_prediction", 100, False,
+        )
+        existing_pred_texts = {
+            e.get("text", "").strip().lower() for e in _existing_raw
+        }
+
         predictions_added = 0
+        pred_collected_ids: list[str] = []
         for pred in predictions:
             if predictions_added >= max_predictions:
                 break
@@ -1042,6 +1167,13 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
                 continue
             text = pred.get("text", "").strip()
             pred_type = pred.get("type", "behavioral")
+            valid, reason = _validate_dreaming_output(
+                text, "prediction", pred,
+                {"activity_summary": content, "existing_texts": existing_pred_texts},
+            )
+            if not valid:
+                logger.info("Dreaming prediction rejected: %s", reason)
+                continue
             if text:
                 # Validate structured temporal suffix if present.
                 if pred_type == "temporal" and "||" not in text:
@@ -1070,8 +1202,13 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
                     )
                 except Exception:  # noqa: BLE001
                     logger.debug("Dreaming: prediction accuracy upsert failed", exc_info=True)
+                pred_collected_ids.append(entry_id)
                 predictions_added += 1
                 logger.info("Dreaming prediction: %s", text[:100])
+        if pred_collected_ids:
+            await database.async_call(
+                database.record_dreaming_entries, "prediction", pred_collected_ids,
+            )
         result.items_processed = predictions_added
         result.summary = f"added {predictions_added} predictions"
     except Exception:  # noqa: BLE001
@@ -1165,6 +1302,58 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
 # Dream Cycle Runner
 # ═══════════════════════════════════════════════════════════════════════════════
 
+async def _check_survival(cfg: dict) -> dict[str, bool]:
+    """Check dreaming entry survival rates and decide which phases to run.
+
+    Returns ``{phase_name: should_run}`` for each creative phase.
+    Phases with insufficient data default to enabled.
+    """
+    threshold = cfg.get("quality_survival_threshold", 0.3)
+    min_cycles = cfg.get("quality_min_cycles", 3)
+    lookback = cfg.get("quality_lookback_cycles", 5)
+    force_enable = set(cfg.get("quality_force_enable_phases", []))
+
+    result: dict[str, bool] = {}
+    for phase in ("association", "schema", "prediction"):
+        if phase in force_enable:
+            result[phase] = True
+            continue
+        try:
+            # Check unchecked rows and update survival counts.
+            unchecked = await database.async_call(
+                database.get_unchecked_dreaming_entries, phase,
+            )
+            for row in unchecked:
+                entry_ids = _json.loads(row["entry_ids"])
+                surviving = await asyncio.to_thread(
+                    memory_store.exists_batch, entry_ids,
+                )
+                await database.async_call(
+                    database.update_dreaming_survival, row["id"], len(surviving),
+                )
+
+            # Compute rate and decide.
+            rate = await database.async_call(
+                database.get_phase_survival_rate, phase, lookback,
+            )
+            if rate is not None and rate < threshold:
+                # Need enough cycles before auto-disabling.
+                total_checked = len(unchecked)  # approximate
+                if total_checked >= min_cycles or rate == 0.0:
+                    logger.warning(
+                        "Dreaming: auto-disabling phase '%s' "
+                        "(survival rate %.1f%% < %.1f%% threshold)",
+                        phase, rate * 100, threshold * 100,
+                    )
+                    result[phase] = False
+                    continue
+            result[phase] = True
+        except Exception:  # noqa: BLE001
+            logger.debug("Dreaming: survival check failed for %s", phase, exc_info=True)
+            result[phase] = True  # fail-open
+    return result
+
+
 async def run_dream_cycle(
     pool: "BackendPool",
     event_bus: "EventBus | None" = None,
@@ -1199,29 +1388,60 @@ async def run_dream_cycle(
         logger.exception("Dreaming: similarity computation failed")
         report.errors.append("similarity computation failed")
 
-    # Define phase roster.
-    phases: list[tuple[str, Any]] = []
+    # Define phase roster: housekeeping first, then creative.
+    housekeeping_phases: list[tuple[str, Any]] = [
+        ("dedup", lambda: _phase_dedup(pool, cfg, sim_data)),
+        ("contradiction", lambda: _phase_contradiction(pool, cfg, sim_data)),
+        ("stale_pruning", lambda: _phase_stale_pruning(pool, cfg, sim_data)),
+        ("task_consolidation", lambda: _phase_task_consolidation(pool, cfg, sim_data)),
+        ("skill_consolidation", lambda: _phase_skill_consolidation(pool, cfg, sim_data)),
+    ]
 
-    phases.append(("dedup", lambda: _phase_dedup(pool, cfg, sim_data)))
-    phases.append(("contradiction",
-                    lambda: _phase_contradiction(pool, cfg, sim_data)))
-    phases.append(("stale_pruning",
-                    lambda: _phase_stale_pruning(pool, cfg, sim_data)))
-    phases.append(("task_consolidation",
-                    lambda: _phase_task_consolidation(pool, cfg, sim_data)))
-    phases.append(("skill_consolidation",
-                    lambda: _phase_skill_consolidation(pool, cfg, sim_data)))
+    creative_phases: list[tuple[str, Any]] = [
+        ("association", lambda: _phase_association(pool, cfg, sim_data)),
+        ("schema", lambda: _phase_schema(pool, cfg, sim_data)),
+        ("prediction", lambda: _phase_prediction(pool, cfg, sim_data)),
+    ]
 
-    # Creative phases (gated by conditions).
-    phases.append(("association",
-                    lambda: _phase_association(pool, cfg, sim_data)))
-    phases.append(("schema",
-                    lambda: _phase_schema(pool, cfg, sim_data)))
-    phases.append(("prediction",
-                    lambda: _phase_prediction(pool, cfg, sim_data)))
+    # Run housekeeping first (deletions may affect survival checks).
+    phases: list[tuple[str, Any]] = list(housekeeping_phases)
 
-    # Execute phases sequentially.
+    # Execute housekeeping, then check survival to gate creative phases.
     for phase_name, phase_fn in phases:
+        logger.info("Dreaming: starting phase '%s'", phase_name)
+        if event_bus:
+            event_bus.emit("dreaming.phase_started", phase=phase_name)
+        try:
+            phase_result = await phase_fn()
+            report.results.append(phase_result)
+            report.phases_run.append(phase_name)
+            if event_bus:
+                event_bus.emit(
+                    "dreaming.phase_completed",
+                    phase=phase_name,
+                    items=phase_result.items_processed,
+                    summary=phase_result.summary,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Dreaming: phase '%s' failed: %s", phase_name, exc)
+            report.errors.append(f"{phase_name}: {exc}")
+            report.results.append(PhaseResult(
+                phase_name=phase_name, error=str(exc),
+                summary=f"failed: {exc}",
+            ))
+
+    # Check quality metrics to gate creative phases.
+    should_run = await _check_survival(cfg)
+
+    # Execute creative phases, filtered by survival check.
+    for phase_name, phase_fn in creative_phases:
+        if not should_run.get(phase_name, True):
+            logger.info("Dreaming: skipping phase '%s' (auto-disabled by quality metrics)", phase_name)
+            report.results.append(PhaseResult(
+                phase_name=phase_name,
+                summary="auto-disabled (low survival rate)",
+            ))
+            continue
         logger.info("Dreaming: starting phase '%s'", phase_name)
         if event_bus:
             event_bus.emit("dreaming.phase_started", phase=phase_name)

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -135,15 +135,18 @@ async def _consolidate(pool: "BackendPool",
 
 def _validate_dreaming_output(
     text: str, phase: str, parsed: dict, context: dict,
+    *, cfg: dict | None = None,
 ) -> tuple[bool, str]:
     """Programmatic structural validation for creative-phase outputs.
 
     Returns ``(True, "")`` on pass or ``(False, reason)`` on reject.
     Fail-open: exceptions inside validation allow the entry through.
+    Pass *cfg* to avoid redundant config file reads inside tight loops.
     """
     try:
         # ── Common checks ──────────────────────────────────────────
-        cfg = _load_dreaming_config()
+        if cfg is None:
+            cfg = _load_dreaming_config()
         default_min = 20 if phase == "prediction" else 15
         min_len = cfg.get("confidence_min_text_length", default_min)
         if len(text) < min_len:
@@ -840,6 +843,7 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
     assoc_prompt = prompt_loader.load("DREAM_ASSOCIATION_PROMPT.txt")
     max_insights = cfg["association_max_insights"]
     insights_created = 0
+    collected_ids: list[str] = []
 
     try:
         raw = await _consolidate(
@@ -852,7 +856,6 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
             return result
 
         insights = parsed.get("insights", [])
-        collected_ids: list[str] = []
         for insight in insights:
             if insights_created >= max_insights:
                 break
@@ -861,7 +864,7 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
                 continue
             text = insight.get("text", "").strip()
             valid, reason = _validate_dreaming_output(
-                text, "association", insight, {"seed_texts": seed_texts},
+                text, "association", insight, {"seed_texts": seed_texts}, cfg=cfg,
             )
             if not valid:
                 logger.info("Dreaming association rejected: %s", reason)
@@ -873,15 +876,20 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
                 collected_ids.append(eid)
                 insights_created += 1
                 logger.info("Dreaming association insight: %s", text[:100])
-        if collected_ids:
-            await database.async_call(
-                database.record_dreaming_entries, "association",
-                list(dict.fromkeys(collected_ids)),
-            )
     except Exception:  # noqa: BLE001
         logger.exception("Dreaming: association phase LLM failed")
         result.error = "LLM call failed"
         result.summary = "LLM call failed"
+
+    # Record outside the try block so already-added IDs are tracked even on
+    # partial failure (e.g. embedding backend error midway through the loop).
+    if collected_ids:
+        await database.async_call(
+            database.record_dreaming_entries, "association",
+            list(dict.fromkeys(collected_ids)),
+        )
+
+    if result.error:
         return result
 
     result.items_processed = insights_created
@@ -989,7 +997,7 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
 
             valid, reason = _validate_dreaming_output(
                 schema_text, "schema", parsed,
-                {"cluster_texts": cluster_texts},
+                {"cluster_texts": cluster_texts}, cfg=cfg,
             )
             if not valid:
                 logger.info("Dreaming schema rejected: %s", reason)
@@ -1147,6 +1155,7 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
     # Call LLM for pattern synthesis.
     pred_prompt = prompt_loader.load("DREAM_PREDICTION_PROMPT.txt")
     max_predictions = cfg["prediction_max_predictions"]
+    pred_collected_ids: list[str] = []
 
     try:
         raw = await _consolidate(
@@ -1172,7 +1181,6 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
                 existing_pred_texts.add(_normalized)
 
         predictions_added = 0
-        pred_collected_ids: list[str] = []
         for pred in predictions:
             if predictions_added >= max_predictions:
                 break
@@ -1184,6 +1192,7 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
             valid, reason = _validate_dreaming_output(
                 text, "prediction", pred,
                 {"activity_summary": content, "existing_texts": existing_pred_texts},
+                cfg=cfg,
             )
             if not valid:
                 logger.info("Dreaming prediction rejected: %s", reason)
@@ -1223,18 +1232,20 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
                 pred_collected_ids.append(entry_id)
                 predictions_added += 1
                 logger.info("Dreaming prediction: %s", text[:100])
-        # Deduplicate entry IDs before recording (model may repeat itself).
-        pred_collected_ids = list(dict.fromkeys(pred_collected_ids))
-        if pred_collected_ids:
-            await database.async_call(
-                database.record_dreaming_entries, "prediction", pred_collected_ids,
-            )
         result.items_processed = predictions_added
         result.summary = f"added {predictions_added} predictions"
     except Exception:  # noqa: BLE001
         logger.exception("Dreaming: prediction phase LLM failed")
         result.summary = "LLM call failed"
         result.error = "LLM call failed"
+
+    # Record outside the try block so already-added IDs are tracked even on
+    # partial failure (e.g. embedding backend error midway through the loop).
+    if pred_collected_ids:
+        unique_pred_ids = list(dict.fromkeys(pred_collected_ids))
+        await database.async_call(
+            database.record_dreaming_entries, "prediction", unique_pred_ids,
+        )
 
     # Validate old predictions: prune unaccessed ones older than 30 days,
     # promote frequently-accessed ones (>= 5 accesses) to dreaming_schema.
@@ -1343,14 +1354,24 @@ async def _check_survival(cfg: dict) -> dict[str, bool]:
             unchecked = await database.async_call(
                 database.get_unchecked_dreaming_entries, phase,
             )
-            for row in unchecked:
-                entry_ids = _json.loads(row["entry_ids"])
-                surviving = await asyncio.to_thread(
-                    memory_store.exists_batch, entry_ids,
-                )
-                await database.async_call(
-                    database.update_dreaming_survival, row["id"], len(surviving),
-                )
+            if unchecked:
+                # Decode all entry IDs and issue a single batched lookup to
+                # avoid one backend round-trip per row.
+                row_entry_ids: dict = {
+                    row["id"]: _json.loads(row["entry_ids"]) for row in unchecked
+                }
+                all_entry_ids = [eid for ids in row_entry_ids.values() for eid in ids]
+                surviving_set: set[str] = set()
+                if all_entry_ids:
+                    surviving_set = await asyncio.to_thread(
+                        memory_store.exists_batch, all_entry_ids,
+                    )
+                for row in unchecked:
+                    ids = row_entry_ids.get(row["id"], [])
+                    survived = sum(1 for eid in ids if eid in surviving_set)
+                    await database.async_call(
+                        database.update_dreaming_survival, row["id"], survived,
+                    )
 
             # Compute rate and decide.
             rate_info = await database.async_call(

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -164,9 +164,11 @@ def _validate_dreaming_output(
 
         # ── Association-specific ───────────────────────────────────
         if phase == "association":
-            source_indices = parsed.get("source_indices", [])
+            source_indices = parsed.get("source_indices")
             seed_texts = context.get("seed_texts", [])
-            if seed_texts and isinstance(source_indices, list):
+            if seed_texts:
+                if not isinstance(source_indices, list):
+                    return False, "missing_source_indices"
                 if len(source_indices) < 2:
                     return False, "too_few_sources"
                 if any(
@@ -1230,9 +1232,9 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
         result.items_processed = predictions_added
         result.summary = f"added {predictions_added} predictions"
     except Exception:  # noqa: BLE001
-        logger.exception("Dreaming: prediction phase LLM failed")
-        result.summary = "LLM call failed"
-        result.error = "LLM call failed"
+        logger.exception("Dreaming: prediction phase failed")
+        result.summary = "phase failed"
+        result.error = "phase failed"
 
     # Record outside the try block so already-added IDs are tracked even on
     # partial failure (e.g. embedding backend error midway through the loop).
@@ -1363,11 +1365,14 @@ async def _check_survival(cfg: dict) -> dict[str, bool]:
                     surviving_set = await asyncio.to_thread(
                         memory_store.exists_batch, all_entry_ids,
                     )
+                survival_updates = []
                 for row in unchecked:
                     ids = row_entry_ids.get(row["id"], [])
                     survived = sum(1 for eid in ids if eid in surviving_set)
+                    survival_updates.append((row["id"], survived))
+                if survival_updates:
                     await database.async_call(
-                        database.update_dreaming_survival, row["id"], survived,
+                        database.batch_update_dreaming_survival, survival_updates,
                     )
 
             # Compute rate and decide.

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -170,7 +170,7 @@ def _validate_dreaming_output(
                 if len(source_indices) < 2:
                     return False, "too_few_sources"
                 if any(
-                    not isinstance(idx, int) or idx >= len(seed_texts)
+                    not isinstance(idx, int) or idx < 0 or idx >= len(seed_texts)
                     for idx in source_indices
                 ):
                     return False, "invalid_source_index"
@@ -1188,6 +1188,17 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
             if confidence not in ("high", "medium"):
                 continue
             text = pred.get("text", "").strip()
+            # Normalize temporal suffix BEFORE duplicate detection so the
+            # comparison uses the same canonical form as stored entries.
+            # e.g. "foo||hours=1||days=mon||" → "foo ||hours=1|| ||days=mon||"
+            if "||" in text:
+                suffix_match = re.search(r'(?:\s*\|\|\w+=[\w,\-]+\|\|)+\s*$', text)
+                if suffix_match:
+                    suffix_parts = re.findall(r'\|\|(\w+=[\w,\-]+)\|\|', suffix_match.group(0))
+                    if suffix_parts:
+                        normalized_suffix = " ".join(f"||{p}||" for p in suffix_parts)
+                        base_text = text[:suffix_match.start()].rstrip()
+                        text = f"{base_text} {normalized_suffix}" if base_text else normalized_suffix
             pred_type = pred.get("type", "behavioral")
             valid, reason = _validate_dreaming_output(
                 text, "prediction", pred,
@@ -1200,22 +1211,6 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
             # Re-read type — validator may have downgraded temporal → behavioral.
             pred_type = pred.get("type", "behavioral")
             if text:
-                # Validate structured temporal suffix if present.
-                if pred_type == "temporal" and "||" not in text:
-                    # No structured suffix — leave as-is for legacy compat.
-                    pass
-                elif "||" in text:
-                    # Normalize: ensure suffix is well-formed.
-                    # Match trailing block of one or more segments, supporting
-                    # both spaced (||hours=..|| ||days=..||) and adjacent
-                    # (||hours=..||days=..||) forms.
-                    suffix_match = re.search(r'(?:\s*\|\|\w+=[\w,\-]+\|\|)+\s*$', text)
-                    if suffix_match:
-                        suffix_parts = re.findall(r'\|\|(\w+=[\w,\-]+)\|\|', suffix_match.group(0))
-                        if suffix_parts:
-                            normalized = " ".join(f"||{p}||" for p in suffix_parts)
-                            base_text = text[:suffix_match.start()].rstrip()
-                            text = f"{base_text} {normalized}" if base_text else normalized
                 tagged = f"[prediction:{pred_type}] {text}"
                 entry_id = await asyncio.to_thread(
                     memory_store.add, tagged, None, "dreaming_prediction"
@@ -1360,7 +1355,9 @@ async def _check_survival(cfg: dict) -> dict[str, bool]:
                 row_entry_ids: dict = {
                     row["id"]: _json.loads(row["entry_ids"]) for row in unchecked
                 }
-                all_entry_ids = [eid for ids in row_entry_ids.values() for eid in ids]
+                all_entry_ids = list(dict.fromkeys(
+                    eid for ids in row_entry_ids.values() for eid in ids
+                ))
                 surviving_set: set[str] = set()
                 if all_entry_ids:
                     surviving_set = await asyncio.to_thread(

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -875,7 +875,8 @@ async def _phase_association(pool: "BackendPool", cfg: dict,
                 logger.info("Dreaming association insight: %s", text[:100])
         if collected_ids:
             await database.async_call(
-                database.record_dreaming_entries, "association", collected_ids,
+                database.record_dreaming_entries, "association",
+                list(dict.fromkeys(collected_ids)),
             )
     except Exception:  # noqa: BLE001
         logger.exception("Dreaming: association phase LLM failed")
@@ -979,7 +980,6 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
             )
             parsed = parse_json_from_llm(raw, dict)
             schema_text = parsed.get("schema", "").strip()
-            replaces = parsed.get("replaces_entries", False)
             confidence = parsed.get("confidence", "medium")
 
             if not schema_text:
@@ -994,6 +994,9 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
             if not valid:
                 logger.info("Dreaming schema rejected: %s", reason)
                 continue
+
+            # Re-read replaces after validation (validator may have downgraded it).
+            replaces = parsed.get("replaces_entries", False)
 
             # Store the schema.
             eid = await asyncio.to_thread(
@@ -1025,7 +1028,8 @@ async def _phase_schema(pool: "BackendPool", cfg: dict,
 
     if schema_collected_ids:
         await database.async_call(
-            database.record_dreaming_entries, "schema", schema_collected_ids,
+            database.record_dreaming_entries, "schema",
+            list(dict.fromkeys(schema_collected_ids)),
         )
     result.items_processed = schemas_formed
     result.summary = f"formed {schemas_formed} schemas from {len(clusters)} clusters"
@@ -1156,9 +1160,16 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
         _existing_raw = await asyncio.to_thread(
             memory_store.get_by_source, "dreaming_prediction", 100, False,
         )
-        existing_pred_texts = {
-            e.get("text", "").strip().lower() for e in _existing_raw
-        }
+        _pred_tag_re = re.compile(r'^\[prediction:[^\]]+\]\s*', re.IGNORECASE)
+        existing_pred_texts: set[str] = set()
+        for _e in _existing_raw:
+            _raw = (_e.get("text", "") or "").strip()
+            # Stored predictions are tagged "[prediction:<type>] <text>"; strip
+            # the tag so duplicate detection compares plain text (as the
+            # validator receives it).
+            _normalized = _pred_tag_re.sub("", _raw).strip().lower()
+            if _normalized:
+                existing_pred_texts.add(_normalized)
 
         predictions_added = 0
         pred_collected_ids: list[str] = []
@@ -1342,14 +1353,13 @@ async def _check_survival(cfg: dict) -> dict[str, bool]:
                 )
 
             # Compute rate and decide.
-            rate = await database.async_call(
+            rate_info = await database.async_call(
                 database.get_phase_survival_rate, phase, lookback,
             )
+            rate = rate_info[0] if rate_info is not None else None
+            checked_count = rate_info[1] if rate_info is not None else 0
             if rate is not None and rate < threshold:
-                # Use the configured lookback window as an approximation of
-                # how many cycles contribute to the computed survival rate,
-                # rather than the number of newly checked rows in this run.
-                if lookback >= min_cycles or rate == 0.0:
+                if checked_count >= min_cycles or rate == 0.0:
                     logger.warning(
                         "Dreaming: auto-disabling phase '%s' "
                         "(survival rate %.1f%% < %.1f%% threshold)",

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -152,8 +152,8 @@ def _validate_dreaming_output(
         if len(text) < min_len:
             return False, f"too_short ({len(text)}<{min_len})"
 
-        # 3+ consecutive identical words → hallucination loop
-        words = text.split()
+        # 3+ consecutive identical words → hallucination loop (case-insensitive)
+        words = [w.casefold() for w in text.split()]
         for i in range(len(words) - 2):
             if words[i] == words[i + 1] == words[i + 2]:
                 return False, "consecutive_repeat"
@@ -1201,7 +1201,6 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
                         normalized_suffix = " ".join(f"||{p}||" for p in suffix_parts)
                         base_text = text[:suffix_match.start()].rstrip()
                         text = f"{base_text} {normalized_suffix}" if base_text else normalized_suffix
-            pred_type = pred.get("type", "behavioral")
             valid, reason = _validate_dreaming_output(
                 text, "prediction", pred,
                 {"activity_summary": content, "existing_texts": existing_pred_texts},
@@ -1339,7 +1338,13 @@ async def _check_survival(cfg: dict) -> dict[str, bool]:
     threshold = cfg.get("quality_survival_threshold", 0.3)
     min_cycles = cfg.get("quality_min_cycles", 3)
     lookback = cfg.get("quality_lookback_cycles", 5)
-    force_enable = set(cfg.get("quality_force_enable_phases", []))
+    _raw_force = cfg.get("quality_force_enable_phases", [])
+    if _raw_force is None:
+        force_enable: set[str] = set()
+    elif isinstance(_raw_force, str):
+        force_enable = {_raw_force}
+    else:
+        force_enable = {v for v in _raw_force if isinstance(v, str)}
 
     result: dict[str, bool] = {}
     for phase in ("association", "schema", "prediction"):

--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -143,7 +143,9 @@ def _validate_dreaming_output(
     """
     try:
         # ── Common checks ──────────────────────────────────────────
-        min_len = 20 if phase == "prediction" else 15
+        cfg = _load_dreaming_config()
+        default_min = 20 if phase == "prediction" else 15
+        min_len = cfg.get("confidence_min_text_length", default_min)
         if len(text) < min_len:
             return False, f"too_short ({len(text)}<{min_len})"
 
@@ -193,7 +195,8 @@ def _validate_dreaming_output(
             activity = context.get("activity_summary", "")
             if activity:
                 from difflib import SequenceMatcher
-                if SequenceMatcher(None, text.lower(), activity.lower()).ratio() > 0.7:
+                max_overlap = cfg.get("confidence_max_input_overlap", 0.7)
+                if SequenceMatcher(None, text.lower(), activity.lower()).ratio() > max_overlap:
                     return False, "parrots_input"
             # Duplicate detection
             existing = context.get("existing_texts", set())
@@ -1174,6 +1177,8 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
             if not valid:
                 logger.info("Dreaming prediction rejected: %s", reason)
                 continue
+            # Re-read type — validator may have downgraded temporal → behavioral.
+            pred_type = pred.get("type", "behavioral")
             if text:
                 # Validate structured temporal suffix if present.
                 if pred_type == "temporal" and "||" not in text:
@@ -1202,9 +1207,13 @@ async def _phase_prediction(pool: "BackendPool", cfg: dict,
                     )
                 except Exception:  # noqa: BLE001
                     logger.debug("Dreaming: prediction accuracy upsert failed", exc_info=True)
+                # Update duplicate-detection set so later iterations catch repeats.
+                existing_pred_texts.add(text.strip().lower())
                 pred_collected_ids.append(entry_id)
                 predictions_added += 1
                 logger.info("Dreaming prediction: %s", text[:100])
+        # Deduplicate entry IDs before recording (model may repeat itself).
+        pred_collected_ids = list(dict.fromkeys(pred_collected_ids))
         if pred_collected_ids:
             await database.async_call(
                 database.record_dreaming_entries, "prediction", pred_collected_ids,
@@ -1337,9 +1346,10 @@ async def _check_survival(cfg: dict) -> dict[str, bool]:
                 database.get_phase_survival_rate, phase, lookback,
             )
             if rate is not None and rate < threshold:
-                # Need enough cycles before auto-disabling.
-                total_checked = len(unchecked)  # approximate
-                if total_checked >= min_cycles or rate == 0.0:
+                # Use the configured lookback window as an approximation of
+                # how many cycles contribute to the computed survival rate,
+                # rather than the number of newly checked rows in this run.
+                if lookback >= min_cycles or rate == 0.0:
                     logger.warning(
                         "Dreaming: auto-disabling phase '%s' "
                         "(survival rate %.1f%% < %.1f%% threshold)",


### PR DESCRIPTION
## Summary

- **Compaction prompt examples**: 2 few-shot examples in `COMPACTION_PROMPT.txt` guiding weak models toward structured summaries (merge, supersession, grouped bullets)
- **Memory write validation**: `_validate_memory_entry()` gate in `append_memory()` — rejects garbage from harvest/tool writes (too short/long, raw JSON, system prompt echoes, repetitive loops, encoding artifacts). Fail-open.
- **Dreaming confidence gating**: `_validate_dreaming_output()` structural validators in all 3 creative phases — per-phase checks include near-copy detection, source index bounds, input-parrot ratio, duplicate predictions, temporal suffix validation. Malformed temporal predictions downgraded to behavioral rather than rejected.
- **Dreaming quality metrics**: `dreaming_quality` table tracks entry survival rates across cycles. `exists_batch()` added to both vector backends. `run_dream_cycle` restructured: housekeeping phases run first, then survival check gates creative phases. Auto-disables phases when survival rate drops below 30% over 3+ cycles, with `quality_force_enable_phases` config override.

## Test plan

- [ ] `uv run python -c "from wintermute.infra.memory_io import _validate_memory_entry"` — import check
- [ ] Verify `_validate_memory_entry` rejects garbage inputs (too short, JSON, system echoes, repetitive)
- [ ] Verify `_validate_dreaming_output` rejects per-phase invalid outputs (near-copies, parroting, duplicates)
- [ ] Run `/compact` and verify few-shot examples produce well-structured summaries
- [ ] Run `/dream` and check logs for `rejected:` entries from confidence gating
- [ ] After 2+ dream cycles, verify `dreaming_quality` table has survival data
- [ ] Verify `quality_force_enable_phases` config override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)