### PR TITLE
fix(tasks): support updating ai_prompt/execution_mode; make DB authoritative at fire time

### DIFF
--- a/wintermute/tools/task_tools.py
+++ b/wintermute/tools/task_tools.py
@@ -218,9 +218,19 @@ def _task_update(inputs: dict, effective_scope: Optional[str],
     if "ai_prompt" in inputs or "execution_mode" in inputs:
         task = database.get_task(task_id)
         if not task:
-            return json.dumps({"error": "task not found"})
-        new_ai_prompt = (inputs.get("ai_prompt") or "").strip() or task.get("ai_prompt") or None
-        new_execution_mode = (inputs.get("execution_mode") or "").strip() or task.get("execution_mode") or None
+            return json.dumps({"status": "not_found"})
+        if task.get("thread_id") != effective_scope:
+            return json.dumps({"status": "not_found"})
+        if "ai_prompt" in inputs:
+            raw_ai_prompt = (inputs.get("ai_prompt") or "").strip()
+            new_ai_prompt = raw_ai_prompt or None
+        else:
+            new_ai_prompt = task.get("ai_prompt")
+        if "execution_mode" in inputs:
+            raw_execution_mode = (inputs.get("execution_mode") or "").strip()
+            new_execution_mode = raw_execution_mode or None
+        else:
+            new_execution_mode = task.get("execution_mode")
         try:
             resolved_mode, _ = _resolve_execution_mode(
                 schedule_type=task.get("schedule_type"),

--- a/wintermute/tools/task_tools.py
+++ b/wintermute/tools/task_tools.py
@@ -215,6 +215,25 @@ def _task_update(inputs: dict, effective_scope: Optional[str],
         kwargs["content"] = inputs["content"]
     if "priority" in inputs:
         kwargs["priority"] = int(inputs["priority"])
+    if "ai_prompt" in inputs or "execution_mode" in inputs:
+        task = database.get_task(task_id)
+        if not task:
+            return json.dumps({"error": "task not found"})
+        new_ai_prompt = (inputs.get("ai_prompt") or "").strip() or task.get("ai_prompt") or None
+        new_execution_mode = (inputs.get("execution_mode") or "").strip() or task.get("execution_mode") or None
+        try:
+            resolved_mode, _ = _resolve_execution_mode(
+                schedule_type=task.get("schedule_type"),
+                ai_prompt=new_ai_prompt,
+                execution_mode=new_execution_mode,
+                background=bool(task.get("background")),
+            )
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+        if "ai_prompt" in inputs:
+            kwargs["ai_prompt"] = new_ai_prompt
+        if "execution_mode" in inputs:
+            kwargs["execution_mode"] = resolved_mode
     ok = database.update_task(task_id, thread_id=effective_scope, **kwargs)
     return json.dumps({"status": "ok" if ok else "not_found"})
 

--- a/wintermute/workers/scheduler_thread.py
+++ b/wintermute/workers/scheduler_thread.py
@@ -382,10 +382,16 @@ class TaskScheduler:
             )
             self.remove_job(task_id)
             return
-        # Prefer DB schedule_type as the authoritative value; fall back to job kwargs.
+        # Prefer DB values as authoritative over stale APScheduler job kwargs.
         db_schedule_type = task_row.get("schedule_type")
         if db_schedule_type:
             schedule_type = db_schedule_type
+        db_ai_prompt = task_row.get("ai_prompt")
+        if db_ai_prompt is not None:
+            ai_prompt = db_ai_prompt or None
+        db_execution_mode = task_row.get("execution_mode")
+        if db_execution_mode is not None:
+            execution_mode = db_execution_mode or None
 
         raw_mode = execution_mode
         mode = (execution_mode or "").strip() or None

--- a/wintermute/workers/scheduler_thread.py
+++ b/wintermute/workers/scheduler_thread.py
@@ -386,12 +386,10 @@ class TaskScheduler:
         db_schedule_type = task_row.get("schedule_type")
         if db_schedule_type:
             schedule_type = db_schedule_type
-        db_ai_prompt = task_row.get("ai_prompt")
-        if db_ai_prompt is not None:
-            ai_prompt = db_ai_prompt or None
-        db_execution_mode = task_row.get("execution_mode")
-        if db_execution_mode is not None:
-            execution_mode = db_execution_mode or None
+        if "ai_prompt" in task_row:
+            ai_prompt = task_row.get("ai_prompt") or None
+        if "execution_mode" in task_row:
+            execution_mode = task_row.get("execution_mode") or None
 
         raw_mode = execution_mode
         mode = (execution_mode or "").strip() or None


### PR DESCRIPTION
## Summary

- `_task_update` now accepts `ai_prompt` and `execution_mode` fields, validated through `_resolve_execution_mode` (same logic as `_task_add`)
- `_fire_task` now re-reads `ai_prompt` and `execution_mode` from the DB row at fire time, overriding stale APScheduler job kwargs — completing the pattern already established for `schedule_type`

## Motivation

Previously, updating a scheduled task's execution properties required deleting and recreating it. The LLM would correctly emit update actions with these fields (the NL translator prompt already supports them), but the backend silently dropped them. Additionally, even if the DB had been updated, the APScheduler job would fire with the original kwargs — the DB was not yet authoritative for these fields.

## How it works

APScheduler job kwargs are set at creation time and become stale after a task update. `_fire_task` already fetched the DB row to check `status` and override `schedule_type`. Extending that to `ai_prompt` and `execution_mode` means the DB becomes the single source of truth for all mutable task properties — no need to touch APScheduler on update.

## Test plan

- [ ] Create a scheduled task with `execution_mode=reminder`
- [ ] Update it to `execution_mode=autonomous_notify` with an `ai_prompt` — verify next fire uses the new mode
- [ ] Update `ai_prompt` on an existing autonomous task — verify next fire uses the updated prompt
- [ ] Attempt invalid combos (e.g. `execution_mode=reminder` + `ai_prompt`) — verify error is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)