### PR TITLE
fix: web interface bugs — HTTP status codes, system prompt fallback, frontend error handling

### DIFF
--- a/wintermute/interfaces/static/debug.html
+++ b/wintermute/interfaces/static/debug.html
@@ -722,6 +722,7 @@ async function loadTab(name) {
 // ── SSE stream ──
 function connectStream() {
   const es = new EventSource('/api/stream');
+  window.addEventListener('beforeunload', () => es.close());
   const statusEl = document.getElementById('stream-status');
   es.onopen = () => {
     statusEl.innerHTML = '<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:currentColor"></span> live';
@@ -751,6 +752,7 @@ function renderSessions(sessions) {
 
 async function loadSessions() {
   const r = await fetch('/api/sessions');
+  if (!r.ok) return;
   const d = await r.json();
   renderSessions(d.sessions || []);
 }
@@ -808,6 +810,7 @@ async function loadSessionMessages(threadId) {
   const type = sessionType(threadId);
 
   const r = await fetch('/api/sessions/' + encodeURIComponent(threadId) + '/messages');
+  if (!r.ok) return;
   const data = await r.json();
   const msgs = data.messages || [];
 
@@ -880,6 +883,7 @@ async function deleteSession() {
   if (!selectedSession) return;
   if (!confirm('Archive all messages for session ' + selectedSession + '? (Same as /new in chat)')) return;
   const r = await fetch('/api/sessions/' + encodeURIComponent(selectedSession) + '/delete', {method: 'POST'});
+  if (!r.ok) { alert('Error: server returned ' + r.status); return; }
   const data = await r.json();
   if (data.ok) { selectedSession = null; await loadSessions(); }
   else alert('Error: ' + (data.error || JSON.stringify(data)));
@@ -892,6 +896,7 @@ async function compactSession() {
   btn.textContent = 'Compacting\u2026';
   try {
     const r = await fetch('/api/sessions/' + encodeURIComponent(selectedSession) + '/compact', {method: 'POST'});
+    if (!r.ok) { alert('Error: server returned ' + r.status); return; }
     const data = await r.json();
     if (data.ok) await loadSessionMessages(selectedSession);
     else alert('Error: ' + (data.error || JSON.stringify(data)));
@@ -927,6 +932,11 @@ async function showSystemPrompt() {
   document.body.appendChild(modal);
   try {
     const r = await fetch('/api/system-prompt');
+    if (!r.ok) {
+      document.getElementById('sp-section').textContent = 'Error: server returned ' + r.status;
+      document.getElementById('tools-section').textContent = '';
+      return;
+    }
     const data = await r.json();
     if (data.error) {
       document.getElementById('sp-section').textContent = 'Error: ' + data.error;
@@ -936,9 +946,11 @@ async function showSystemPrompt() {
     const spTok    = data.sp_tokens || 0;
     const toolsTok = data.tools_tokens || 0;
     const total    = data.tokens || (spTok + toolsTok);
+    const fallbackNote = data.fallback ? ' (approximate \u2014 no inference has run yet)' : '';
     document.getElementById('sp-stats').textContent =
-      `${fmtTokens(total)} tok total \u2022 ${data.pct}% of context`;
+      `${fmtTokens(total)} tok total \u2022 ${data.pct}% of context` + fallbackNote;
     document.getElementById('sp-token-bar').innerHTML =
+      (data.fallback ? '<span style="color:#f0ad4e;font-size:.72rem">\u26a0 Assembled from template \u2014 memories and ranked skills not included</span>' : '') +
       `<span style="color:#8899aa">SP: <strong>${fmtTokens(spTok)}</strong> tok</span>` +
       `<span style="color:#c9b0ff">Tools: <strong>${fmtTokens(toolsTok)}</strong> tok</span>` +
       `<span style="color:#666">Limit: ${fmtTokens(data.total_limit)} tok</span>`;
@@ -1157,8 +1169,9 @@ function renderWorkers(sessions, workflows) {
 
   const wfIds = Object.keys(wfSessions);
   wfIds.sort((a, b) => {
-    const ta = Math.max(...wfSessions[a].map(s => new Date(s.created_at)));
-    const tb = Math.max(...wfSessions[b].map(s => new Date(s.created_at)));
+    const sa = wfSessions[a], sb = wfSessions[b];
+    const ta = sa.length ? Math.max(...sa.map(s => new Date(s.created_at))) : 0;
+    const tb = sb.length ? Math.max(...sb.map(s => new Date(s.created_at))) : 0;
     return tb - ta;
   });
 
@@ -1230,6 +1243,7 @@ async function loadWorkers() {
     fetch('/api/subsessions'),
     fetch('/api/workflows'),
   ]);
+  if (!r1.ok || !r2.ok) return;
   const [d1, d2] = await Promise.all([r1.json(), r2.json()]);
   renderWorkers(d1.sessions || [], d2.workflows || []);
 }
@@ -1257,6 +1271,7 @@ async function fetchWorkerDetail(sid) {
   if (!el) return;
   try {
     const r = await fetch('/api/subsessions/' + encodeURIComponent(sid) + '/messages');
+    if (!r.ok) { el.innerHTML = '<span style="color:#ff9090">Server error (' + r.status + ')</span>'; return; }
     const data = await r.json();
     const msgs = data.messages || [];
     if (!msgs.length) {
@@ -1314,6 +1329,7 @@ async function fetchScratchpad(wfId) {
   el.innerHTML = 'Loading\u2026';
   try {
     const r = await fetch('/api/workflows/' + encodeURIComponent(wfId) + '/scratchpad');
+    if (!r.ok) { el.innerHTML = '<span style="color:#ff9090">Server error (' + r.status + ')</span>'; return; }
     const data = await r.json();
     if (data.error) {
       el.innerHTML = '<span style="color:#ff9090">' + esc(data.error) + '</span>';
@@ -1379,6 +1395,7 @@ function renderJobs(jobs) {
 
 async function loadJobs() {
   const r = await fetch('/api/jobs');
+  if (!r.ok) return;
   const d = await r.json();
   renderJobs(d.jobs || []);
 }
@@ -1410,6 +1427,7 @@ function renderTasks(items) {
 
 async function loadTasks() {
   const r = await fetch('/api/tasks');
+  if (!r.ok) return;
   const d = await r.json();
   renderTasks(d.items || []);
 }
@@ -1457,13 +1475,15 @@ function _fetchIL({limit = 200, before_id, after_id} = {}) {
   if (before_id != null) params.set('before_id', before_id);
   if (after_id != null)  params.set('after_id', after_id);
   return fetch('/api/interaction-log?' + params)
-    .then(r => r.json()).then(d => d.entries || []);
+    .then(r => { if (!r.ok) return {entries: []}; return r.json(); })
+    .then(d => d.entries || []);
 }
 
 async function _refreshILSessions() {
   const filterSel = document.getElementById('il-filter-session');
   const currentFilter = filterSel.value;
   const r = await fetch('/api/interaction-log?limit=1000&offset=0');
+  if (!r.ok) return;
   const d = await r.json();
   const sessions = [...new Set((d.entries || []).map(e => e.session).filter(Boolean))];
   const existing = new Set([...filterSel.options].map(o => o.value));
@@ -1552,6 +1572,7 @@ async function toggleILDetail(row, id) {
     return;
   }
   const r = await fetch('/api/interaction-log/' + id);
+  if (!r.ok) return;
   const e = await r.json();
   const detail = document.createElement('tr');
   detail.className = 'il-detail';
@@ -1654,6 +1675,7 @@ async function loadOutcomes() {
       fetch('/api/outcomes?' + params),
       fetch('/api/cp-violations'),
     ]);
+    if (!r.ok || !tpR.ok) return;
     const d = await r.json();
     const tpData = await tpR.json();
     const entries = d.entries || [];
@@ -2028,6 +2050,7 @@ async function deleteSkill(name) {
 async function loadConfig() {
   try {
     const r = await fetch('/api/config');
+    if (!r.ok) return;
     const d = await r.json();
     const el = document.getElementById('cfg-info');
     const parts = [];

--- a/wintermute/interfaces/web_interface.py
+++ b/wintermute/interfaces/web_interface.py
@@ -177,6 +177,22 @@ class WebInterface:
     def _json(data, *, status: int = 200) -> web.Response:
         return web.Response(text=json.dumps(data), content_type="application/json", status=status)
 
+    def _error_response(
+        self,
+        message: str = "Internal server error",
+        *,
+        status: int = 500,
+        exc: Exception | None = None,
+    ) -> web.Response:
+        """
+        Build a generic JSON error response and log the underlying exception.
+
+        This avoids sending potentially sensitive exception details to clients.
+        """
+        if exc is not None:
+            logger.exception("Unhandled exception in API: %s", message)
+        return self._json({"error": message}, status=status)
+
     def _token_budget(self, thread_id: str = "default") -> dict:
         """Delegate to LLMThread.get_token_budget() for accurate accounting."""
         if self._llm:
@@ -291,7 +307,7 @@ class WebInterface:
             _task.add_done_callback(self._background_tasks.discard)
             return self._json({"ok": True, "thread_id": thread_id})
         except Exception as exc:  # noqa: BLE001
-            return self._json({"error": str(exc)}, status=500)
+            return self._error_response("Failed to send session request", status=500, exc=exc)
 
     async def _api_session_delete(self, request: web.Request) -> web.Response:
         thread_id = request.match_info["thread_id"]
@@ -305,7 +321,7 @@ class WebInterface:
                 pass
             return self._json({"ok": True, "thread_id": thread_id})
         except Exception as exc:  # noqa: BLE001
-            return self._json({"error": str(exc)}, status=500)
+            return self._error_response("Failed to delete session", status=500, exc=exc)
 
     async def _api_session_compact(self, request: web.Request) -> web.Response:
         thread_id = request.match_info["thread_id"]
@@ -313,7 +329,7 @@ class WebInterface:
             await self._llm.force_compact(thread_id)
             return self._json({"ok": True, "thread_id": thread_id})
         except Exception as exc:  # noqa: BLE001
-            return self._json({"error": str(exc)}, status=500)
+            return self._error_response("Failed to compact session", status=500, exc=exc)
 
     async def _api_config(self, _request: web.Request) -> web.Response:
         def _backend_list(configs):
@@ -471,7 +487,8 @@ class WebInterface:
                 try:
                     content = p.read_text(errors="replace")
                 except Exception as exc:
-                    content = f"[read error: {exc}]"
+                    logger.exception("Failed to read scratchpad file %s", p)
+                    content = "[read error]"
                 files.append({"name": p.name, "size": p.stat().st_size, "content": content})
         return self._json({"workflow_id": workflow_id, "files": files, "exists": True})
 
@@ -564,7 +581,8 @@ class WebInterface:
             for key, value in body.items():
                 mgr.set(thread_id, key, value)
         except (ValueError, TypeError) as exc:
-            return self._json({"error": str(exc)}, status=400)
+            logger.exception("Invalid thread configuration for %s", thread_id)
+            return self._json({"error": "Invalid thread configuration"}, status=400)
         resolved_dict = mgr.resolve_as_dict(thread_id)
         return self._json({"ok": True, "resolved": resolved_dict})
 
@@ -707,7 +725,8 @@ class WebInterface:
             all_skills = skill_store.get_all()
             store_stats = skill_store.stats()
         except Exception as exc:
-            return self._json({"error": str(exc), "skills": [], "count": 0}, status=500)
+            logger.exception("Failed to list skills")
+            return self._json({"error": "Failed to list skills", "skills": [], "count": 0}, status=500)
 
         for rec in all_skills:
             name = rec["name"]

--- a/wintermute/interfaces/web_interface.py
+++ b/wintermute/interfaces/web_interface.py
@@ -174,8 +174,8 @@ class WebInterface:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _json(data) -> web.Response:
-        return web.Response(text=json.dumps(data), content_type="application/json")
+    def _json(data, *, status: int = 200) -> web.Response:
+        return web.Response(text=json.dumps(data), content_type="application/json", status=status)
 
     def _token_budget(self, thread_id: str = "default") -> dict:
         """Delegate to LLMThread.get_token_budget() for accurate accounting."""
@@ -291,7 +291,7 @@ class WebInterface:
             _task.add_done_callback(self._background_tasks.discard)
             return self._json({"ok": True, "thread_id": thread_id})
         except Exception as exc:  # noqa: BLE001
-            return self._json({"error": str(exc)})
+            return self._json({"error": str(exc)}, status=500)
 
     async def _api_session_delete(self, request: web.Request) -> web.Response:
         thread_id = request.match_info["thread_id"]
@@ -305,7 +305,7 @@ class WebInterface:
                 pass
             return self._json({"ok": True, "thread_id": thread_id})
         except Exception as exc:  # noqa: BLE001
-            return self._json({"error": str(exc)})
+            return self._json({"error": str(exc)}, status=500)
 
     async def _api_session_compact(self, request: web.Request) -> web.Response:
         thread_id = request.match_info["thread_id"]
@@ -313,7 +313,7 @@ class WebInterface:
             await self._llm.force_compact(thread_id)
             return self._json({"ok": True, "thread_id": thread_id})
         except Exception as exc:  # noqa: BLE001
-            return self._json({"error": str(exc)})
+            return self._json({"error": str(exc)}, status=500)
 
     async def _api_config(self, _request: web.Request) -> web.Response:
         def _backend_list(configs):
@@ -344,14 +344,28 @@ class WebInterface:
     async def _api_system_prompt(self, _request: web.Request) -> web.Response:
         # Show the exact system prompt last sent to the LLM (includes
         # vector-ranked memories, compaction summary, etc.).
-        # Never fall back to re-assembling — a re-assembled prompt would show
-        # (all) skills instead of the actual ranked subset, no memories, etc.
+        # Falls back to a freshly assembled prompt (without ranked memories)
+        # when no cached version exists yet (e.g. after a restart).
         thread_id = _request.query.get("thread", "default")
         prompt = None
+        is_fallback = False
         if self._llm:
             prompt = self._llm.get_last_system_prompt(thread_id)
         if prompt is None:
-            return self._json({"error": f"No system prompt cached yet for thread '{thread_id}'. Send a message first."})
+            # Assemble an approximate prompt so the debug panel is useful
+            # even before the first inference call (e.g. after restart).
+            try:
+                from wintermute.infra import prompt_assembler
+                summary = None
+                if self._llm and hasattr(self._llm, '_store'):
+                    summary = self._llm._store.compaction_summaries.get(thread_id)
+                prompt = prompt_assembler.assemble(extra_summary=summary)
+                is_fallback = True
+            except Exception:  # noqa: BLE001
+                return self._json(
+                    {"error": f"Could not assemble system prompt for thread '{thread_id}'."},
+                    status=503,
+                )
         from wintermute.core.llm_thread import _count_tokens
         _cfg = self._main_pool.primary if (self._main_pool and self._main_pool.enabled) else None
         model = _cfg.model if _cfg else "gpt-4"
@@ -382,7 +396,7 @@ class WebInterface:
         tools_tokens = _count_tokens(json.dumps(active_schemas), model)
         total_limit = max(_cfg.context_size - _cfg.max_tokens, 1) if _cfg else 4096
         combined_tokens = sp_tokens + tools_tokens
-        return self._json({
+        result = {
             "prompt": prompt,
             "sp_tokens": sp_tokens,
             "tools_tokens": tools_tokens,
@@ -390,7 +404,10 @@ class WebInterface:
             "total_limit": total_limit,
             "pct": round(min(combined_tokens / total_limit * 100, 100), 1),
             "tool_schemas": active_schemas,
-        })
+        }
+        if is_fallback:
+            result["fallback"] = True
+        return self._json(result)
 
     # ------------------------------------------------------------------
     # REST API — sub-sessions
@@ -444,7 +461,7 @@ class WebInterface:
         workflow_id = request.match_info["workflow_id"]
         # Sanitise: only allow alphanumeric, dash, underscore
         if not all(c.isalnum() or c in "-_" for c in workflow_id):
-            return self._json({"error": "invalid workflow_id"})
+            return self._json({"error": "invalid workflow_id"}, status=400)
         scratchpad_dir = Path("data/scratchpad") / workflow_id
         if not scratchpad_dir.is_dir():
             return self._json({"workflow_id": workflow_id, "files": [], "exists": False})
@@ -484,7 +501,7 @@ class WebInterface:
         """GET /api/thread-config — list all overrides + available backends."""
         mgr = getattr(self, "_thread_config_manager", None)
         if mgr is None:
-            return self._json({"error": "Thread config not available"})
+            return self._json({"error": "Thread config not available"}, status=503)
         overrides = mgr.get_all_overrides()
         backends = sorted(mgr.get_available_backends())
         return self._json({
@@ -512,7 +529,7 @@ class WebInterface:
         """GET /api/thread-config/{thread_id} — resolved config with sources."""
         mgr = getattr(self, "_thread_config_manager", None)
         if mgr is None:
-            return self._json({"error": "Thread config not available"})
+            return self._json({"error": "Thread config not available"}, status=503)
         thread_id = request.match_info["thread_id"]
         resolved_dict = mgr.resolve_as_dict(thread_id)
         raw = mgr.get(thread_id)
@@ -537,7 +554,7 @@ class WebInterface:
         """POST /api/thread-config/{thread_id} — set overrides (JSON body)."""
         mgr = getattr(self, "_thread_config_manager", None)
         if mgr is None:
-            return self._json({"error": "Thread config not available"})
+            return self._json({"error": "Thread config not available"}, status=503)
         thread_id = request.match_info["thread_id"]
         try:
             body = await request.json()
@@ -547,7 +564,7 @@ class WebInterface:
             for key, value in body.items():
                 mgr.set(thread_id, key, value)
         except (ValueError, TypeError) as exc:
-            return self._json({"error": str(exc)})
+            return self._json({"error": str(exc)}, status=400)
         resolved_dict = mgr.resolve_as_dict(thread_id)
         return self._json({"ok": True, "resolved": resolved_dict})
 
@@ -555,7 +572,7 @@ class WebInterface:
         """DELETE /api/thread-config/{thread_id} — remove all overrides."""
         mgr = getattr(self, "_thread_config_manager", None)
         if mgr is None:
-            return self._json({"error": "Thread config not available"})
+            return self._json({"error": "Thread config not available"}, status=503)
         thread_id = request.match_info["thread_id"]
         mgr.reset(thread_id)
         return self._json({"ok": True})
@@ -690,7 +707,7 @@ class WebInterface:
             all_skills = skill_store.get_all()
             store_stats = skill_store.stats()
         except Exception as exc:
-            return self._json({"error": str(exc), "skills": [], "count": 0})
+            return self._json({"error": str(exc), "skills": [], "count": 0}, status=500)
 
         for rec in all_skills:
             name = rec["name"]


### PR DESCRIPTION
## Summary

- **System prompt fallback**: `/api/system-prompt` now assembles a fresh prompt via `prompt_assembler.assemble()` when the in-memory cache is empty (e.g. after restart), instead of returning a misleading "Send a message first" error. Response includes `"fallback": true` flag; frontend shows a warning banner.
- **Proper HTTP status codes**: Added `status` parameter to `_json()` helper. Fixed 10 error responses across session, thread-config, scratchpad, and skills endpoints that incorrectly returned HTTP 200 with error payloads.
- **EventSource leak**: Added `beforeunload` listener to close the SSE connection on page unload/refresh.
- **Frontend error handling**: Added `r.ok` checks to 13 `fetch()` calls in the debug panel that silently failed on server errors.
- **Math.max guard**: Protected `renderWorkers()` sort against empty arrays producing `-Infinity`.

## Test plan

- [ ] Restart wintermute, open `/debug`, click "System Prompt" — should show assembled prompt with fallback warning instead of error
- [ ] Send a message, reopen modal — should show cached prompt without fallback warning
- [ ] Trigger a backend error (e.g. stop LLM thread) and verify debug panel fetch calls show errors gracefully
- [ ] Check browser DevTools network tab: error API responses should return proper 4xx/5xx status codes
- [ ] Open `/debug`, close tab — verify no lingering EventSource connections in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)