### PR TITLE
fix: protect skill merge targets from contradictory deletes

### DIFF
--- a/wintermute/workers/dreaming.py
+++ b/wintermute/workers/dreaming.py
@@ -653,10 +653,19 @@ async def _phase_skill_consolidation(pool: "BackendPool", cfg: dict,
             )
             raw = await _consolidate(pool, "skills_dedup", dedup_prompt, formatted)
             actions = parse_json_from_llm(raw, list)
+            # Protect merge targets from contradictory delete instructions.
+            merge_targets = {
+                act.get("into") for act in actions if act.get("action") == "merge"
+            }
             for act in actions:
                 action = act.get("action")
                 name = act.get("file", "")
                 if action == "delete":
+                    if name in merge_targets:
+                        logger.warning(
+                            "Dreaming: skipping delete of merge target '%s'", name
+                        )
+                        continue
                     if name in skills:
                         skill_store.delete(name)
                         del skills[name]


### PR DESCRIPTION
## Summary
- During nightly dreaming skill dedup, the LLM (deepseek-chat on March 20) produced contradictory actions: merging `caldav-auto-accept-next-14-days` INTO `caldav-calendar-query`, then also marking `caldav-calendar-query` for deletion — destroying both skills permanently
- Adds a pre-pass that collects all merge `into` targets and skips any `delete` action that would destroy a merge target

## Test plan
- [ ] Verify dreaming skill dedup runs without regression
- [ ] Simulate contradictory LLM output (merge + delete same target) and confirm the delete is skipped with a warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)