### PR TITLE
feat: add send_message tool, fix send_file sub-session routing

### DIFF
--- a/data/prompts/NL_TRANSLATOR_TASK.txt
+++ b/data/prompts/NL_TRANSLATOR_TASK.txt
@@ -31,8 +31,8 @@ Translate natural-language task descriptions into JSON arguments. Output ONLY va
 6. "reason" is mandatory for complete. Infer from context if not stated.
 7. Emit `execution_mode` for every scheduled task. Use `reminder` for reminders/notifications, `autonomous_notify` when autonomous output should be posted to chat, and `autonomous_silent` only when the user explicitly asks for silent background maintenance.
 8. Scheduled autonomous work (`autonomous_notify`/`autonomous_silent`) requires `ai_prompt` with a self-contained instruction including tool names (search_web, fetch_url, execute_shell, read_file).
-9. For reminder/notification phrasing (e.g., 'remind me', 'send a reminder', 'water reminder', 'notify me to'), default to `execution_mode=reminder`.
-10. Add `ai_prompt` only when user intent clearly asks autonomous execution (e.g., research, summarize, analyze, fetch data, modify files, run commands). If ambiguous, prefer `execution_mode=reminder`.
+9. For reminder/notification phrasing (e.g., 'remind me', 'send a reminder', 'water reminder', 'notify me to', 'medication reminder', 'remind me to take'), default to `execution_mode=reminder`. The `reminder` mode already sends the `content` as a chat message — there is NO need for ai_prompt to "send" or "deliver" a message.
+10. Add `ai_prompt` only when user intent clearly asks for autonomous *computation* the AI must perform (e.g., research, summarize, analyze, fetch data, modify files, run commands). Sending a message, displaying a notification, or reminding the user is NOT autonomous computation — use `reminder`. If ambiguous, prefer `execution_mode=reminder`.
 11. Do not emit `background` unless explicitly asked to generate legacy-compatible payloads.
 
 ## Examples
@@ -73,3 +73,9 @@ CORRECT — genuine reminder, no action verb the AI can execute:
 "send a water reminder notification to user now"
 CORRECT — this is a reminder/notification task, keep it passive:
 {{"action": "add", "content": "Drink water", "schedule_type": "once", "at": "2026-03-02T10:00:00+01:00", "execution_mode": "reminder"}}
+
+"medication reminder daily at 6am — send 'Zeit für deine Tabletten! 💊'"
+WRONG — autonomous_notify with ai_prompt that just sends a message (reminder mode already does this):
+{{"action": "add", "content": "Medication reminder - tablets", "schedule_type": "daily", "at": "06:00", "execution_mode": "autonomous_notify", "ai_prompt": "Check current time. If it's 06:00 CET, send chat message 'Zeit für deine Tabletten! 💊' and mark task complete."}}
+CORRECT — simple reminder, the content IS the message:
+{{"action": "add", "content": "Zeit für deine Tabletten! 💊", "schedule_type": "daily", "at": "06:00", "execution_mode": "reminder"}}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-Wintermute exposes 11 tools as OpenAI-compatible function-calling schemas, compatible with any OpenAI-compatible endpoint (llama-server, vLLM, LM Studio, OpenAI, etc.).
+Wintermute exposes 12 tools as OpenAI-compatible function-calling schemas, compatible with any OpenAI-compatible endpoint (llama-server, vLLM, LM Studio, OpenAI, etc.).
 
 ## Tool Categories
 
@@ -8,9 +8,10 @@ Tools are grouped into three categories that control which tools are available i
 
 | Category | Available To | Tools |
 |----------|-------------|-------|
-| **execution** | All agents | `execute_shell`, `read_file`, `write_file`, `send_file` |
+| **execution** | All agents | `execute_shell`, `read_file`, `write_file`, `send_message` |
 | **research** | All agents | `search_web`, `fetch_url`, `skill` |
 | **orchestration** | Main agent + `full`-mode sub-sessions | `worker_delegation`, `task`, `append_memory`, `query_telemetry` |
+| *(uncategorized)* | Main agent only | `send_file`, `restart_self` |
 
 ## Tool Filtering by Sub-session Mode
 
@@ -83,9 +84,21 @@ Write content to a file, creating parent directories as needed.
 | `path` | string | yes | Absolute or relative file path |
 | `content` | string | yes | Text content to write |
 
+#### `send_message`
+
+Send a text message directly to the user's chat. Use for notifications, alerts, and reminders from sub-sessions — not for normal conversation replies (those go through the standard inference flow). Frontend-agnostic: emits a `send_message` event on the EventBus; each frontend (Matrix, Signal) subscribes and handles delivery independently.
+
+When called from a sub-session, the message is routed to the originating chat thread (via `parent_thread_id`), not the sub-session itself.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | yes | The message text to send to the user |
+
+Returns: `status`, `thread_id`
+
 #### `send_file`
 
-Send a file to the user. Images are sent inline; other files as downloads. Frontend-agnostic: emits a `send_file` event on the EventBus; each frontend (Matrix, web) subscribes and handles delivery independently.
+Send a file to the user. Images are sent inline; other files as downloads. Frontend-agnostic: emits a `send_file` event on the EventBus; each frontend (Matrix, Signal) subscribes and handles delivery independently. Main agent only — not available in sub-sessions.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-Wintermute exposes 12 tools as OpenAI-compatible function-calling schemas, compatible with any OpenAI-compatible endpoint (llama-server, vLLM, LM Studio, OpenAI, etc.).
+Wintermute exposes 13 tools as OpenAI-compatible function-calling schemas, compatible with any OpenAI-compatible endpoint (llama-server, vLLM, LM Studio, OpenAI, etc.).
 
 ## Tool Categories
 
@@ -8,10 +8,11 @@ Tools are grouped into three categories that control which tools are available i
 
 | Category | Available To | Tools |
 |----------|-------------|-------|
-| **execution** | All agents | `execute_shell`, `read_file`, `write_file`, `send_message` |
+| **execution** | All agents | `execute_shell`, `read_file`, `write_file`, `send_file`*, `send_message` |
 | **research** | All agents | `search_web`, `fetch_url`, `skill` |
 | **orchestration** | Main agent + `full`-mode sub-sessions | `worker_delegation`, `task`, `append_memory`, `query_telemetry`, `restart_self` |
-| *(uncategorized)* | Main agent only | `send_file` |
+
+\* `send_file` is categorized as execution but excluded from sub-sessions by default (`SUB_SESSION_EXCLUDE`). Sub-sessions can still receive it via an explicit `tool_names` whitelist or custom profile.
 
 ## Tool Filtering by Sub-session Mode
 
@@ -98,7 +99,7 @@ Returns: `status`, `thread_id`
 
 #### `send_file`
 
-Send a file to the user. Images are sent inline; other files as downloads. Frontend-agnostic: emits a `send_file` event on the EventBus; each frontend (Matrix, Signal) subscribes and handles delivery independently. Main agent only — not available in sub-sessions.
+Send a file to the user. Images are sent inline; other files as downloads. Frontend-agnostic: emits a `send_file` event on the EventBus; each frontend (Matrix, Signal) subscribes and handles delivery independently. Excluded from sub-sessions by default; only available if explicitly granted via `tool_names` or a custom profile.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,8 +10,8 @@ Tools are grouped into three categories that control which tools are available i
 |----------|-------------|-------|
 | **execution** | All agents | `execute_shell`, `read_file`, `write_file`, `send_message` |
 | **research** | All agents | `search_web`, `fetch_url`, `skill` |
-| **orchestration** | Main agent + `full`-mode sub-sessions | `worker_delegation`, `task`, `append_memory`, `query_telemetry` |
-| *(uncategorized)* | Main agent only | `send_file`, `restart_self` |
+| **orchestration** | Main agent + `full`-mode sub-sessions | `worker_delegation`, `task`, `append_memory`, `query_telemetry`, `restart_self` |
+| *(uncategorized)* | Main agent only | `send_file` |
 
 ## Tool Filtering by Sub-session Mode
 

--- a/wintermute/core/sub_session.py
+++ b/wintermute/core/sub_session.py
@@ -1693,6 +1693,7 @@ class SubSessionManager:
             tool_schemas = tool_module.get_tool_schemas(
                 categories, nl_tools=nl_tools,
                 tool_profiles=self._tool_deps.tool_profiles if self._tool_deps else None,
+                exclude_names=tool_module.SUB_SESSION_EXCLUDE,
             )
 
         # Resolve per-session pool overrides for CP and NL translation.

--- a/wintermute/core/tool_schemas.py
+++ b/wintermute/core/tool_schemas.py
@@ -441,6 +441,7 @@ TOOL_CATEGORIES: dict[str, str] = {
     "read_file":          "execution",
     "write_file":         "execution",
     "search_web":         "research",
+    "send_file":          "execution",
     "send_message":       "execution",
     "fetch_url":          "research",
     "worker_delegation":  "orchestration",
@@ -450,6 +451,10 @@ TOOL_CATEGORIES: dict[str, str] = {
     "query_telemetry":    "orchestration",
     "restart_self":       "orchestration",
 }
+
+# Tools excluded from sub-sessions by default (main-agent only).
+# Sub-sessions can still receive these via explicit tool_names whitelist.
+SUB_SESSION_EXCLUDE: frozenset[str] = frozenset({"send_file"})
 
 
 NL_TOOL_SCHEMAS = [

--- a/wintermute/core/tool_schemas.py
+++ b/wintermute/core/tool_schemas.py
@@ -169,7 +169,8 @@ TOOL_SCHEMAS = [
                     "description": (
                         "Instruction for autonomous execution. Required when "
                         "execution_mode is autonomous_notify or "
-                        "autonomous_silent."
+                        "autonomous_silent. Do NOT use for simple reminders — "
+                        "reminder mode already delivers the content as a chat message."
                     ),
                 },
                 "execution_mode": {
@@ -378,6 +379,21 @@ TOOL_SCHEMAS = [
         },
     ),
     _fn(
+        "send_message",
+        "Send a text message directly to the user's chat. "
+        "Use this for notifications, alerts, and reminders — NOT for normal conversation replies.",
+        {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The message text to send to the user.",
+                },
+            },
+            "required": ["text"],
+        },
+    ),
+    _fn(
         "fetch_url",
         "Fetch a web page and return it as plain text (HTML stripped).",
         {
@@ -425,7 +441,7 @@ TOOL_CATEGORIES: dict[str, str] = {
     "read_file":          "execution",
     "write_file":         "execution",
     "search_web":         "research",
-    "send_file":          "execution",
+    "send_message":       "execution",
     "fetch_url":          "research",
     "worker_delegation":  "orchestration",
     "task":               "orchestration",

--- a/wintermute/interfaces/matrix_thread.py
+++ b/wintermute/interfaces/matrix_thread.py
@@ -276,11 +276,13 @@ class MatrixThread:
         self._slash_handler = slash_handler
         # Kimi-Code client for interactive auth flow.
         self._kimi_client = kimi_client
-        # Subscribe to send_file events from the tool.
+        # Subscribe to tool delivery events.
         self._event_bus = event_bus
+        self._send_file_sub_id: Optional[str] = None
+        self._send_message_sub_id: Optional[str] = None
         if event_bus is not None:
-            event_bus.subscribe("send_file", self._handle_send_file_event)
-            event_bus.subscribe("send_message", self._handle_send_message_event)
+            self._send_file_sub_id = event_bus.subscribe("send_file", self._handle_send_file_event)
+            self._send_message_sub_id = event_bus.subscribe("send_message", self._handle_send_message_event)
 
     # ------------------------------------------------------------------
     # Public interface
@@ -518,6 +520,13 @@ class MatrixThread:
 
     def stop(self) -> None:
         self._running = False
+        if self._event_bus is not None:
+            if self._send_file_sub_id is not None:
+                self._event_bus.unsubscribe(self._send_file_sub_id)
+                self._send_file_sub_id = None
+            if self._send_message_sub_id is not None:
+                self._event_bus.unsubscribe(self._send_message_sub_id)
+                self._send_message_sub_id = None
         if self._client is not None:
             self._client.stop()
 

--- a/wintermute/interfaces/matrix_thread.py
+++ b/wintermute/interfaces/matrix_thread.py
@@ -280,6 +280,7 @@ class MatrixThread:
         self._event_bus = event_bus
         if event_bus is not None:
             event_bus.subscribe("send_file", self._handle_send_file_event)
+            event_bus.subscribe("send_message", self._handle_send_message_event)
 
     # ------------------------------------------------------------------
     # Public interface
@@ -343,6 +344,19 @@ class MatrixThread:
         if thread_id.startswith("sig_") or thread_id.startswith("web_"):
             return
         await self._send_file(file_path, thread_id)
+
+    async def _handle_send_message_event(self, event) -> None:
+        """EventBus handler for ``send_message`` events emitted by the tool."""
+        data = event.data if hasattr(event, "data") else event
+        text = data.get("text", "")
+        thread_id = data.get("thread_id", "")
+        if not text or not thread_id:
+            logger.warning("send_message event missing text or thread_id: %s", data)
+            return
+        # Ignore events targeting other interfaces.
+        if thread_id.startswith("sig_") or thread_id.startswith("web_"):
+            return
+        await self.send_message(text, thread_id)
 
     async def _send_file(self, file_path: str, room_id: str,
                          _retries: int = 3, _delay: float = 2.0) -> None:

--- a/wintermute/interfaces/signal_thread.py
+++ b/wintermute/interfaces/signal_thread.py
@@ -94,7 +94,7 @@ class SignalThread:
         self._whisper_language: str = whisper_language
         # Shared slash-command handler.
         self._slash_handler = slash_handler
-        # Subscribe to send_file events from the tool.
+        # Subscribe to tool delivery events (send_file, send_message).
         self._event_bus = event_bus
         self._send_file_sub_id: Optional[str] = None
         self._send_message_sub_id: Optional[str] = None

--- a/wintermute/interfaces/signal_thread.py
+++ b/wintermute/interfaces/signal_thread.py
@@ -97,8 +97,10 @@ class SignalThread:
         # Subscribe to send_file events from the tool.
         self._event_bus = event_bus
         self._send_file_sub_id: Optional[str] = None
+        self._send_message_sub_id: Optional[str] = None
         if event_bus is not None:
             self._send_file_sub_id = event_bus.subscribe("send_file", self._handle_send_file_event)
+            self._send_message_sub_id = event_bus.subscribe("send_message", self._handle_send_message_event)
 
     # ------------------------------------------------------------------
     # Public interface
@@ -186,6 +188,9 @@ class SignalThread:
         if self._event_bus is not None and self._send_file_sub_id is not None:
             self._event_bus.unsubscribe(self._send_file_sub_id)
             self._send_file_sub_id = None
+        if self._event_bus is not None and self._send_message_sub_id is not None:
+            self._event_bus.unsubscribe(self._send_message_sub_id)
+            self._send_message_sub_id = None
         self._kill_process_sync()
 
     # ------------------------------------------------------------------
@@ -724,6 +729,18 @@ class SignalThread:
         if not thread_id.startswith("sig_"):
             return
         await self._send_file(file_path, thread_id)
+
+    async def _handle_send_message_event(self, event) -> None:
+        """EventBus handler for ``send_message`` events — filter by sig_ prefix."""
+        data = event.data if hasattr(event, "data") else event
+        text = data.get("text", "")
+        thread_id = data.get("thread_id", "")
+        if not text or not thread_id:
+            logger.warning("send_message event missing text or thread_id: %s", data)
+            return
+        if not thread_id.startswith("sig_"):
+            return
+        await self.send_message(text, thread_id)
 
     async def _send_file(self, file_path: str, thread_id: str,
                          _retries: int = 3, _delay: float = 2.0) -> None:

--- a/wintermute/tools/__init__.py
+++ b/wintermute/tools/__init__.py
@@ -29,7 +29,7 @@ from wintermute.core.tool_schemas import (  # noqa: F401 — re-exported
 )
 from wintermute.tools.task_tools import tool_task, _describe_schedule  # noqa: F401
 from wintermute.tools.memory_tools import tool_append_memory, tool_skill
-from wintermute.tools.io_tools import tool_execute_shell, tool_read_file, tool_write_file, tool_send_file
+from wintermute.tools.io_tools import tool_execute_shell, tool_read_file, tool_write_file, tool_send_file, tool_send_message
 from wintermute.tools.web_tools import tool_search_web, tool_fetch_url
 from wintermute.tools.session_tools import tool_worker_delegation, tool_query_telemetry
 
@@ -70,6 +70,7 @@ _DISPATCH: dict[str, Any] = {
     "read_file":          tool_read_file,
     "write_file":         tool_write_file,
     "send_file":          tool_send_file,
+    "send_message":       tool_send_message,
     "search_web":         tool_search_web,
     "fetch_url":          tool_fetch_url,
     "query_telemetry":    tool_query_telemetry,

--- a/wintermute/tools/__init__.py
+++ b/wintermute/tools/__init__.py
@@ -23,6 +23,7 @@ from wintermute.core.tool_deps import ToolDeps
 from wintermute.core.tool_schemas import (  # noqa: F401 — re-exported
     TOOL_SCHEMAS,
     TOOL_CATEGORIES,
+    SUB_SESSION_EXCLUDE,
     NL_TOOL_SCHEMAS,
     NL_SCHEMA_MAP,
     get_tool_schemas,

--- a/wintermute/tools/io_tools.py
+++ b/wintermute/tools/io_tools.py
@@ -57,8 +57,23 @@ def tool_write_file(inputs: dict, **_kw) -> str:
         return json.dumps({"error": str(exc)})
 
 
+def _resolve_delivery_thread(thread_id: Optional[str],
+                             parent_thread_id: Optional[str]) -> str:
+    """Pick the user-facing thread for delivery.
+
+    Sub-sessions have ``thread_id=sub_xxx`` (their own session ID) and
+    ``parent_thread_id`` pointing at the originating chat thread.  Tools that
+    deliver content to the user must target the chat thread, not the
+    sub-session.
+    """
+    if parent_thread_id:
+        return parent_thread_id
+    return thread_id or ""
+
+
 def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
-                   thread_id: Optional[str] = None, **_kw) -> str:
+                   thread_id: Optional[str] = None,
+                   parent_thread_id: Optional[str] = None, **_kw) -> str:
     """Validate a file and emit a ``send_file`` event for frontends to handle."""
     import mimetypes
 
@@ -69,6 +84,7 @@ def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
     mime_type = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
     file_size = path.stat().st_size
     caption = inputs.get("caption", "")
+    delivery_thread = _resolve_delivery_thread(thread_id, parent_thread_id)
 
     if tool_deps and tool_deps.event_bus:
         tool_deps.event_bus.emit(
@@ -78,7 +94,7 @@ def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
             mime_type=mime_type,
             file_size=file_size,
             caption=caption,
-            thread_id=thread_id or "",
+            thread_id=delivery_thread,
         )
         logger.info("send_file: emitted event for %s (%s, %d bytes)", path.name, mime_type, file_size)
         return json.dumps({
@@ -90,4 +106,30 @@ def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
         })
 
     logger.warning("send_file: no event_bus available, file not delivered")
+    return json.dumps({"error": "No delivery channel available (event_bus not configured)"})
+
+
+def tool_send_message(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
+                      thread_id: Optional[str] = None,
+                      parent_thread_id: Optional[str] = None, **_kw) -> str:
+    """Emit a ``send_message`` event for frontends to deliver directly."""
+    text = (inputs.get("text") or "").strip()
+    if not text:
+        return json.dumps({"error": "text is required"})
+
+    delivery_thread = _resolve_delivery_thread(thread_id, parent_thread_id)
+    if not delivery_thread:
+        return json.dumps({"error": "No target thread available"})
+
+    if tool_deps and tool_deps.event_bus:
+        tool_deps.event_bus.emit(
+            "send_message",
+            text=text,
+            thread_id=delivery_thread,
+        )
+        logger.info("send_message: emitted event for thread %s (%d chars)",
+                     delivery_thread, len(text))
+        return json.dumps({"status": "ok", "thread_id": delivery_thread})
+
+    logger.warning("send_message: no event_bus available, message not delivered")
     return json.dumps({"error": "No delivery channel available (event_bus not configured)"})

--- a/wintermute/tools/io_tools.py
+++ b/wintermute/tools/io_tools.py
@@ -68,7 +68,11 @@ def _resolve_delivery_thread(thread_id: Optional[str],
     """
     if parent_thread_id:
         return parent_thread_id
-    return thread_id or ""
+    # Sub-session IDs (sub_xxx) are internal and not user-routable;
+    # returning "" causes callers to surface a "No target thread" error.
+    if thread_id and not thread_id.startswith("sub_"):
+        return thread_id
+    return ""
 
 
 def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,

--- a/wintermute/tools/io_tools.py
+++ b/wintermute/tools/io_tools.py
@@ -85,6 +85,8 @@ def tool_send_file(inputs: dict, *, tool_deps: Optional["ToolDeps"] = None,
     file_size = path.stat().st_size
     caption = inputs.get("caption", "")
     delivery_thread = _resolve_delivery_thread(thread_id, parent_thread_id)
+    if not delivery_thread:
+        return json.dumps({"error": "No target thread available"})
 
     if tool_deps and tool_deps.event_bus:
         tool_deps.event_bus.emit(


### PR DESCRIPTION
## Summary

- **New `send_message` tool** for sub-sessions to send text directly to users via EventBus → Matrix/Signal, routing to the correct chat thread via `parent_thread_id`
- **Fix `send_file` thread routing** in sub-sessions: was using the sub-session ID (`sub_xxx`) which no interface could route — now uses `parent_thread_id`
- **Remove `send_file` from sub-session categories** — main-thread only (was broken in sub-sessions, no current use case)
- **Strengthen NL translator task prompt** to prevent weak models from misclassifying simple reminders as `autonomous_notify` with unnecessary `ai_prompt` (triggered by medication reminder producing a hallucinated "message sent" claim)

## Context

Observed in production: a daily medication reminder task was created with `execution_mode=autonomous_notify` + `ai_prompt` instead of `execution_mode=reminder`. The sub-session then claimed it "sent" the reminder message but had no tool to do so — the user only received the main thread's paraphrased relay, not the intended notification text.

## Changes

| File | Change |
|------|--------|
| `wintermute/tools/io_tools.py` | New `tool_send_message()`, `_resolve_delivery_thread()` helper, fix `tool_send_file` to accept `parent_thread_id` |
| `wintermute/core/tool_schemas.py` | `send_message` schema + category; remove `send_file` from categories |
| `wintermute/tools/__init__.py` | Register `send_message` in dispatch |
| `wintermute/interfaces/matrix_thread.py` | Subscribe to `send_message` events |
| `wintermute/interfaces/signal_thread.py` | Subscribe to `send_message` events + cleanup in `stop()` |
| `data/prompts/NL_TRANSLATOR_TASK.txt` | Stronger rules 9-10, negative example for medication reminders |
| `docs/tools.md` | Document `send_message`, update categories table, note `send_file` is main-thread only |

## Test plan

- [ ] Verify `send_message` tool is available in sub-sessions (`execution` category)
- [ ] Verify `send_file` is NOT available in sub-sessions (no category)
- [ ] Create a `reminder` task and verify NL translator produces `execution_mode=reminder` (not `autonomous_notify`)
- [ ] Test `send_message` from a sub-session — message arrives in correct Matrix/Signal thread
- [ ] Test `send_file` from main thread — still works with correct thread routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)